### PR TITLE
Fix/write node order

### DIFF
--- a/src/methods.jl
+++ b/src/methods.jl
@@ -408,7 +408,7 @@ function ladderize!(n::TreeNode)
 			rank[k] = ladderize!(c)
 		end
 
-		n.child = n.child[sortperm(rank; rev=true)]
+		n.child = n.child[reverse(sortperm(rank; rev=true))]
 
 		return sum(rank)
 	end

--- a/src/writing.jl
+++ b/src/writing.jl
@@ -25,8 +25,8 @@ write_newick(root::TreeNode) = write_newick!("", root)*";"
 function write_newick!(s::String, root::TreeNode)
 	if !isempty(root.child)
 		s *= '('
-		temp = sort(root.child, by=x->length(POTleaves(x)))
-		for c in temp
+		# temp = sort(root.child, by=x->length(POTleaves(x)))
+		for c in root.child
 			s = write_newick!(s, c)
 			s *= ','
 		end


### PR DESCRIPTION
Trees were automatically ladderized when written to newick. Caused issue with TreeKnit's disentangling.