### PR TITLE
Change behavior of copy function

### DIFF
--- a/src/methods.jl
+++ b/src/methods.jl
@@ -167,11 +167,13 @@ function _copy!(an::TreeNode{T}, n::TreeNode, i) where T <: TreeNodeData
 	return nothing
 end
 """
-	copy(t::Tree, T::DataType = EmptyData)
-"""
-Base.copy(t::Tree, T::DataType = EmptyData) = node2tree(_copy(t.root, T))
+	copy(t::Tree)
 
-Base.convert(::Type{Tree{EmptyData}}, t::Tree) = copy(t, EmptyData)
+Make a copy of `t`. The copy can be modified without changing `t`.
+"""
+Base.copy(t::Tree{T}) where T <: TreeNodeData = node2tree(_copy(t.root, T))
+
+Base.convert(::Type{Tree{T}}, t::Tree) where T <: TreeNodeData = node2tree(_copy(t.root, T))
 
 ###############################################################################################################
 ################################################### Clades ####################################################

--- a/src/objects.jl
+++ b/src/objects.jl
@@ -1,13 +1,17 @@
 """
 	abstract type TreeNodeData
 
-Abstract supertype for all data attached to `TreeNode` objects.
+Abstract supertype for data attached to the `dat` field of `TreeNode` objects.
+Implemented concrete types are
+- `EmptyData`: empty struct. Use if you do not have to attach data to nodes.
+- `MiscData`: contains a dictionary for attaching extra data to nodes.
 """
 abstract type TreeNodeData end
 
-
 """
 	struct MiscData <: TreeNodeData
+		dat::Dict{Any,Any}
+	end
 """
 struct MiscData <: TreeNodeData
 	dat::Dict{Any,Any}
@@ -15,10 +19,10 @@ end
 MiscData(; dat=Dict()) = MiscData(dat)
 
 """
+	struct EmptyData <: TreeNodeData
 """
 struct EmptyData <: TreeNodeData
 end
-
 
 const DEFAULT_NODE_DATATYPE = EmptyData
 

--- a/src/reading.jl
+++ b/src/reading.jl
@@ -15,7 +15,9 @@ end
 	)
 
 Read Newick file `nw_file` and create a `Tree{NodeDataType}` object from it.
-`NodeDataType` must be a subtype of `TreeNodeData`, and must have a *callable default outer constructor*: the call `NodeDataType()` must exist and return a valid instance of `NodeDataType`.
+`NodeDataType` must be a subtype of `TreeNodeData`, and must have a *callable default outer
+constructor*: the call `NodeDataType()` must exist and return a valid instance of
+`NodeDataType`. See `?TreeNodeData` for implemented types.
 Use `force_new_labels=true` to force the renaming of all internal nodes.
 """
 function read_tree(

--- a/test/methods/test.jl
+++ b/test/methods/test.jl
@@ -36,3 +36,25 @@ end
 	@test count(n -> n.label[1] == 'A', t1.lnodes["AB"]) == 2
 end
 
+@testset "Copy" begin
+	t1 = node2tree(root_1)
+	t2 = copy(t1)
+	@test typeof(t1) == typeof(t2)
+	prunesubtree!(t2, ["A"])
+	@test haskey(t1.lnodes, "A")
+	@test !haskey(t2.lnodes, "A")
+end
+
+@testset "Convert" begin
+	t1 = node2tree(root_1)
+	# Converting to EmptyData and back
+	t2 = convert(Tree{TreeTools.EmptyData}, t1)
+	@test typeof(t2) == Tree{TreeTools.EmptyData}
+	@test typeof(convert(Tree{TreeTools.MiscData}, t2)) == Tree{TreeTools.MiscData}
+
+	# Converting to MiscData and back
+	t2 = convert(Tree{TreeTools.MiscData}, t1)
+	@test typeof(t2) == Tree{TreeTools.MiscData}
+	@test typeof(convert(Tree{TreeTools.EmptyData}, t2)) == Tree{TreeTools.EmptyData}
+end
+


### PR DESCRIPTION
It's now simply `copy(t::Tree)`, and returns a copy of `t` with the same type. The copy is still editable independently from the original. 
*Note*: it used to take the type to copy to as input, *i.e.* `copy(t::Tree, T::TreeNodeData)`, and would copy and convert at the same time. 