### PR TITLE
Better misc data

### DIFF
--- a/src/TreeTools.jl
+++ b/src/TreeTools.jl
@@ -5,7 +5,7 @@ using Random
 ## Iteration
 import Base: eltype, iterate, IteratorEltype, IteratorSize, length
 ## Indexing
-import Base: eachindex, firstindex, getindex, lastindex, setindex!
+import Base: eachindex, firstindex, get!, getindex, lastindex, setindex!
 
 ## Others
 import Base: ==, cat, convert, copy, count, hash, in, intersect
@@ -14,7 +14,7 @@ import Base: union, union!, unique, unique!
 
 ##
 include("objects.jl")
-export Tree, TreeNode, TreeNodeData
+export Tree, TreeNode, TreeNodeData, MiscData
 export isleaf, isroot
 
 include("methods.jl")

--- a/src/methods.jl
+++ b/src/methods.jl
@@ -133,7 +133,7 @@ end
 
 function _copy(r::TreeNode, ::Type{T}) where T <: TreeNodeData
 	!r.isroot && error("Copying non-root node.")
-	data = deepcopy(r.data)
+	data = _copy_data(T, r)
 	child = if r.isleaf
 		Array{TreeNode{T}, 1}(undef, 0)
 	else
@@ -154,7 +154,7 @@ end
 Create a copy of `n` with node data type `T` and add it to the children of `an`.
 """
 function _copy!(an::TreeNode{T}, n::TreeNode, i) where T <: TreeNodeData
-	data = deepcopy(n.data)
+	data = _copy_data(T, n)
 	child = if n.isleaf
 		Array{TreeNode{T}, 1}(undef, 0)
 	else
@@ -173,6 +173,9 @@ function _copy!(an::TreeNode{T}, n::TreeNode, i) where T <: TreeNodeData
 
 	return nothing
 end
+_copy_data(::Type{T}, n::TreeNode{T}) where T <: TreeNodeData = deepcopy(n.data)
+_copy_data(::Type{T}, n::TreeNode) where T <: TreeNodeData = T()
+
 """
 	copy(t::Tree)
 
@@ -180,6 +183,7 @@ Make a copy of `t`. The copy can be modified without changing `t`.
 """
 Base.copy(t::Tree{T}) where T <: TreeNodeData = node2tree(_copy(t.root, T))
 
+Base.convert(::Type{Tree{T}}, t::Tree{T}) where T <: TreeNodeData = t
 Base.convert(::Type{Tree{T}}, t::Tree) where T <: TreeNodeData = node2tree(_copy(t.root, T))
 
 ###############################################################################################################

--- a/src/objects.jl
+++ b/src/objects.jl
@@ -24,10 +24,12 @@ Base.eltype(::Type{MiscData}) = eltype(Dict{Any,Any})
 Base.length(d::MiscData) = length(d.dat)
 
 Base.getindex(d::MiscData, i) = getindex(d.dat, i)
-Base.setindex!(d::MiscData, i) = setindex!(d.dat, i)
+Base.setindex!(d::MiscData, k, v) = setindex!(d.dat, k, v)
 Base.firstindex(d::MiscData, i) = firstindex(d.dat, i)
 Base.lastindex(d::MiscData, i) = lastindex(d.dat, i)
 Base.get!(d::MiscData, k, v) = get!(d.dat, k, v)
+
+Base.haskey(d::MiscData, k) = haskey(d.dat, k)
 
 """
 	struct EmptyData <: TreeNodeData

--- a/src/objects.jl
+++ b/src/objects.jl
@@ -18,6 +18,17 @@ struct MiscData <: TreeNodeData
 end
 MiscData(; dat=Dict()) = MiscData(dat)
 
+Base.iterate(d::MiscData) = iterate(d.dat)
+Base.iterate(d::MiscData, state) = iterate(d.dat, state)
+Base.eltype(::Type{MiscData}) = eltype(Dict{Any,Any})
+Base.length(d::MiscData) = length(d.dat)
+
+Base.getindex(d::MiscData, i) = getindex(d.dat, i)
+Base.setindex!(d::MiscData, i) = setindex!(d.dat, i)
+Base.firstindex(d::MiscData, i) = firstindex(d.dat, i)
+Base.lastindex(d::MiscData, i) = lastindex(d.dat, i)
+Base.get!(d::MiscData, k, v) = get!(d.dat, k, v)
+
 """
 	struct EmptyData <: TreeNodeData
 """

--- a/test/iterators/test.jl
+++ b/test/iterators/test.jl
@@ -5,13 +5,13 @@ println("##### iterators #####")
 
 begin
 	nwk = "(((A1:1,A2:1,B:1,C:1)i_2:0.5,(D1:0,D2:0)i_3:1.5)i_1:1,(E:1.5,(F:1.0,(G:0.,H:0.)i_6:0.5)i_5:1)i_4:1)i_r"
+	tree = parse_newick_string(nwk)
 	tnodes = sort(["A1", "A2", "B", "C", "i_2", "D1", "D2", "i_3", "i_1", "E", "F", "G", "H", "i_6", "i_5", "i_4", "i_r"])
 	tleaves = sort(["A1", "A2", "B", "C", "D1", "D2", "E", "F", "G", "H"])
 
 	@testset "1" begin
-		t = node2tree(TreeTools.parse_newick(nwk))
-		@test sort([x.label for x in POT(t)]) == tnodes
-		@test sort([x.label for x in POTleaves(t)]) == tleaves
+		@test sort([x.label for x in POT(tree)]) == tnodes
+		@test sort([x.label for x in POTleaves(tree)]) == tleaves
 	end
 
 	@testset "in" begin

--- a/test/methods/test.jl
+++ b/test/methods/test.jl
@@ -36,6 +36,14 @@ end
 	@test count(n -> n.label[1] == 'A', t1.lnodes["AB"]) == 2
 end
 
+@testset "Copy type" begin
+	t1 = Tree(TreeNode(MiscData(Dict(1=>2))))
+	tc = copy(t1)
+	@test tc.root.data[1] == 2
+	t1.root.data[1] = 3
+	@test tc.root.data[1] == 2
+end
+
 @testset "Copy" begin
 	t1 = node2tree(root_1)
 	t2 = copy(t1)
@@ -45,16 +53,34 @@ end
 	@test !haskey(t2.lnodes, "A")
 end
 
+
+
 @testset "Convert" begin
-	t1 = node2tree(root_1)
+	t1 = Tree(TreeNode(MiscData(Dict(1=>2))))
+	# No op
+	@test convert(Tree{MiscData}, t1) === t1
+	@test convert(Tree{MiscData}, t1).root.data === t1.root.data
+
 	# Converting to EmptyData and back
 	t2 = convert(Tree{TreeTools.EmptyData}, t1)
+	t3 = convert(Tree{MiscData}, t2)
 	@test typeof(t2) == Tree{TreeTools.EmptyData}
-	@test typeof(convert(Tree{TreeTools.MiscData}, t2)) == Tree{TreeTools.MiscData}
+	@test t2.root.data == TreeTools.EmptyData()
+
+	@test typeof(t3) == Tree{TreeTools.MiscData}
+	@test !haskey(t3.root.data, 1)
+
+	###
+
+	t1 = Tree(TreeNode(TreeTools.EmptyData()))
+	# No op
+	@test convert(Tree{TreeTools.EmptyData}, t1) === t1
 
 	# Converting to MiscData and back
 	t2 = convert(Tree{TreeTools.MiscData}, t1)
 	@test typeof(t2) == Tree{TreeTools.MiscData}
+	@test isempty(t2.root.data)
+
 	@test typeof(convert(Tree{TreeTools.EmptyData}, t2)) == Tree{TreeTools.EmptyData}
 end
 


### PR DESCRIPTION
export `MiscData`, and implements easier indexing into it. It should now be used like a dictionary, *e.g.* for a `n::TreeNode{MiscData}` one can now use `n.data[key]` instead of `n.data.dat[key]`. 