### PR TITLE
works better with arrays/dicts

### DIFF
--- a/src/misc.jl
+++ b/src/misc.jl
@@ -130,7 +130,7 @@ function print_tree_ascii(io, t::Tree)
         depths = [divtime(node, t.root) for node in values(t.lnodes)]
         # If there are no branch lengths, assume unit branch lengths
         if ismissing(maximum(depths))
-            println("\n not all branch lengths known, assuming identical branch lengths")
+            println(io, "\n not all branch lengths known, assuming identical branch lengths")
             depths = [node_depth(node) for node in values(t.lnodes)]
         end
         # Potential drawing overflow due to rounding -- 1 char per tree layer
@@ -195,7 +195,7 @@ function print_tree_ascii(io, t::Tree)
         if i % 2 == 0
             line = line * " " * strip(taxa[round(Int64, i/2)]) #remove white space from labels to make more tidy
         end
-        println(line)
+        println(io, line)
     end
 end
 

--- a/src/misc.jl
+++ b/src/misc.jl
@@ -19,15 +19,43 @@ function showinfo(tree::Tree)
 end
 
 """
-    show(io::IO, tree::Tree, maxnodes=40; kwargs...)
-    show(t::Tree, maxnodes=40; kwargs...)
+    show(io::IO, tree::Tree, maxnodes=40)
+    show(t::Tree, maxnodes=40)
 """
-function Base.show(io::IO, tree::Tree, maxnodes=40; kwargs...)
-    if length(tree.lnodes) < maxnodes
-        print_tree_ascii(io, tree)
+function Base.show(io::IO, t::Tree{T}) where T
+	nn = length(nodes(t))
+	nl = length(leaves(t))
+	long = begin
+		base = "Tree{$T}: "
+		base *= nn > 1 ? "$nn nodes, " : "$nn node, "
+		base *= nl > 1 ? "$nl leaves" : "$nl leaf"
+		base
+	end
+	if length(long) < 0.8*displaysize(io)[2]
+		print(io, long)
+		return nothing
+	end
+
+	short = begin
+		base = "Tree w. "
+		base *= nl > 1 ? "$nl leaves" : "$nl leaf"
+		base
+	end
+	print(io, short)
+	return nothing
+end
+
+function Base.show(io::IO, ::MIME"text/plain", t::Tree; maxnodes=40)
+    if length(nodes(t)) < maxnodes
+        print_tree_ascii(io, t)
+    else
+    	show(io, t)
     end
 end
-Base.show(t::Tree, maxnodes=40; kwargs...) = show(stdout, t, maxnodes; kwargs...)
+
+
+
+
 
 function Base.show(io::IO, n::TreeNode)
     if !get(io, :compact, false)


### PR DESCRIPTION
Large trees and dictionaries of trees are now shown as `Tree{...} x nodes y leaves` 
Arrays of trees show the `print_ascii` version if trees are not too large 