### PR TITLE
Rename `divtime` to `distance`

### DIFF
--- a/src/TreeTools.jl
+++ b/src/TreeTools.jl
@@ -18,7 +18,7 @@ export Tree, TreeNode, TreeNodeData, MiscData
 export isleaf, isroot
 
 include("methods.jl")
-export lca, map!, node2tree, node2tree!, node_depth, divtime, share_labels
+export lca, map!, node2tree, node2tree!, node_depth, distance, divtime, share_labels
 
 include("iterators.jl")
 export POT, POTleaves, nodes, leaves, internals

--- a/src/methods.jl
+++ b/src/methods.jl
@@ -364,7 +364,8 @@ end
 
 
 """
-	distance(n1::TreeNode, n2::TreeNode)
+	distance(t::Tree, n1::AbstractString, n2::AbstractString; topological=false)
+	distance(n1::TreeNode, n2::TreeNode; topological=false)
 
 Compute branch length distance between `n1` and `n2` by summing the `TreeNode.tau` values.
 If `topological`, the value `1` is summed instead of `TreeNode.tau`.
@@ -384,7 +385,11 @@ function distance(i_node::TreeNode, j_node::TreeNode; topological=false)
 	end
 	return tau
 end
+function distance(t::Tree, n1::AbstractString, n2::AbstractString; topological=false)
+	return distance(t.lnodes[n1], t.lnodes[n2]; topological)
+end
 
+# for convenience with old functions -- should be removed eventually
 divtime(i_node, j_node) = distance(i_node, j_node)
 
 """

--- a/src/methods.jl
+++ b/src/methods.jl
@@ -364,25 +364,28 @@ end
 
 
 """
-	divtime(i_node::TreeNode, j_node::TreeNode)
+	distance(n1::TreeNode, n2::TreeNode)
 
-Compute divergence time between `i_node` and `j_node` by summing the `TreeNode.tau` values.
+Compute branch length distance between `n1` and `n2` by summing the `TreeNode.tau` values.
+If `topological`, the value `1` is summed instead of `TreeNode.tau`.
 """
-function divtime(i_node::TreeNode, j_node::TreeNode)
+function distance(i_node::TreeNode, j_node::TreeNode; topological=false)
 	a_node = lca(i_node, j_node)
 	tau = 0.
 	ii_node = i_node
 	jj_node = j_node
 	while ii_node != a_node
-		tau += ii_node.tau
+		tau += topological ? 1. : ii_node.tau
 		ii_node = ii_node.anc
 	end
 	while jj_node != a_node
-		tau += jj_node.tau
+		tau += topological ? 1. : jj_node.tau
 		jj_node = jj_node.anc
 	end
 	return tau
 end
+
+divtime(i_node, j_node) = distance(i_node, j_node)
 
 """
 	isancestor(a:::TreeNode, node::TreeNode)

--- a/test/methods/test.jl
+++ b/test/methods/test.jl
@@ -84,3 +84,19 @@ end
 	@test typeof(convert(Tree{TreeTools.EmptyData}, t2)) == Tree{TreeTools.EmptyData}
 end
 
+nwk = "(A:3,(B:1,C:1):2)"
+@testset "Distance" begin
+	t = parse_newick_string(nwk)
+	# Branch length
+	@test distance(t, "A", "B") == 6
+	@test distance(t.lnodes["A"], t.lnodes["B"]) == 6
+	@test distance(t, "A", "B") == distance(t, "A", "C")
+	@test distance(t.root, t.lnodes["A"]) == 3
+	# Topological
+	@test distance(t.root, t.lnodes["A"]; topological=true) == 1
+	@test distance(t, "A", "B"; topological=true) == distance(t, "A", "C"; topological=true)
+	@test distance(t, "A", "B"; topological=true) == 3
+	# tests below can be removed when `divtime` is removed
+	@test divtime(t.lnodes["A"], t.lnodes["B"]) == 6
+	@test divtime(t.root, t.lnodes["A"]) == 3
+end


### PR DESCRIPTION
New functions names: 
- `distance(n1::TreeNode, n2::TreeNode; topological=false)`
- `distance(t::Tree, n1::AbstractString, n2::AbstractString; topological=false)`
- kept `divtime` for backward compatibility

The `topological` kwarg counts the number of branches separating two nodes without considering branch length 