### PR TITLE
Rename `divtime` to `distance`

### DIFF
--- a/test/methods/test.jl
+++ b/test/methods/test.jl
@@ -96,6 +96,10 @@ nwk = "(A:3,(B:1,C:1):2)"
 	@test distance(t.root, t.lnodes["A"]; topological=true) == 1
 	@test distance(t, "A", "B"; topological=true) == distance(t, "A", "C"; topological=true)
 	@test distance(t, "A", "B"; topological=true) == 3
+	for n in nodes(t)
+		@test distance(t[n.label], t[n.label]; topological=true) == 0
+		@test distance(t[n.label], t[n.label]; topological=false) == 0
+	end
 	# tests below can be removed when `divtime` is removed
 	@test divtime(t.lnodes["A"], t.lnodes["B"]) == 6
 	@test divtime(t.root, t.lnodes["A"]) == 3


### PR DESCRIPTION
New functions names:

- `distance(n1::TreeNode, n2::TreeNode; topological=false)`
- `distance(t::Tree, n1::AbstractString, n2::AbstractString; topological=false)`
- kept `divtime` for backward compatibility

The `topological` kwarg counts the number of branches separating two nodes without considering branch length