### PR TITLE
add children/ancestor/branch_length methods for TreeNode

### DIFF
--- a/src/TreeTools.jl
+++ b/src/TreeTools.jl
@@ -15,7 +15,7 @@ import Base: union, union!, unique, unique!
 ##
 include("objects.jl")
 export Tree, TreeNode, TreeNodeData, MiscData
-export isleaf, isroot
+export isleaf, isroot, ancestor, children, branch_length
 
 include("methods.jl")
 export lca, node2tree, node2tree!, node_depth, distance, divtime, share_labels

--- a/src/objects.jl
+++ b/src/objects.jl
@@ -81,9 +81,6 @@ function TreeNode(;
 )
 	return TreeNode(anc, child, isleaf, isroot, label, tau, data)
 end
-isleaf(n) = n.isleaf
-isroot(n) = n.isroot
-
 
 """
 	==(x::TreeNode, y::TreeNode)
@@ -96,6 +93,11 @@ end
 Base.:(==)(x::TreeNode, y::TreeNode) = isequal(x,y)
 Base.hash(x::TreeNode, h::UInt) = hash(x.label, h)
 
+children(n::TreeNode) = n.child
+ancestor(n::TreeNode) = n.anc
+branch_length(n::TreeNode) = n.tau
+isleaf(n) = n.isleaf
+isroot(n) = n.isroot
 
 """
 	mutable struct Tree{T <: TreeNodeData}


### PR DESCRIPTION
`children(n::TreeNode) = n.child`, and so on ... 
These functions are exported 