### PR TITLE
add label field for Tree objects

### DIFF
--- a/src/TreeTools.jl
+++ b/src/TreeTools.jl
@@ -15,7 +15,7 @@ import Base: union, union!, unique, unique!
 ##
 include("objects.jl")
 export Tree, TreeNode, TreeNodeData, MiscData
-export isleaf, isroot, ancestor, children, branch_length, label
+export isleaf, isroot, ancestor, children, branch_length, label, label!
 
 include("methods.jl")
 export lca, node2tree, node2tree!, node_depth, distance, divtime, share_labels

--- a/src/methods.jl
+++ b/src/methods.jl
@@ -4,15 +4,19 @@
 
 
 """
-	node2tree(root::TreeNode{T}; force_new_labels=false)
+	node2tree(root::TreeNode{T}; label = default_tree_label(), force_new_labels=false)
 
-Create a `Tree` object from `root`.
+Create a `Tree` object from `root` with name `label`. If `force_new_labels`, a random
+string is added to node labels to make them unique.
 """
-function node2tree(root::TreeNode{T}; force_new_labels=false) where T
+function node2tree(
+	root::TreeNode{T};
+	label = default_tree_label(), force_new_labels = false
+) where T
 	if !isroot(root)
 		@warn "Creating a tree from non-root node $(root.label)."
 	end
-	tree = Tree(root, Dict{String, TreeNode{T}}(), Dict{String, TreeNode{T}}())
+	tree = Tree(root, Dict{String, TreeNode{T}}(), Dict{String, TreeNode{T}}(), label)
 	node2tree_addnode!(tree, root; force_new_labels)
 	return tree
 end

--- a/src/objects.jl
+++ b/src/objects.jl
@@ -108,12 +108,15 @@ mutable struct Tree{T <: TreeNodeData}
 	root::Union{Nothing, TreeNode{T}}
 	lnodes::Dict{String, TreeNode{T}}
 	lleaves::Dict{fieldtype(TreeNode{T}, :label), TreeNode{T}}
+	label::String
 end
-function Tree(root::TreeNode{T};
-		lnodes = Dict{String, TreeNode{T}}(root.label => root),
-		lleaves = Dict{fieldtype(TreeNode{T},:label), TreeNode{T}}(root.label => root)
-	) where T
-	return Tree(root, lnodes, lleaves)
+function Tree(
+	root::TreeNode{T};
+	lnodes = Dict{String, TreeNode{T}}(root.label => root),
+	lleaves = Dict{fieldtype(TreeNode{T}, :label), TreeNode{T}}(root.label => root),
+	label = default_tree_label()
+) where T
+	return Tree(root, lnodes, lleaves, label)
 end
 Tree() = Tree(TreeNode())
 
@@ -123,3 +126,7 @@ end
 Base.in(n::TreeNode, t::Tree; exclude_internals=false) = in(n.label, t; exclude_internals)
 
 Base.getindex(t::Tree, label) = getindex(t.lnodes, label)
+
+default_tree_label(n=10) = randstring(n)
+label(t::Tree) = t.label
+label!(t::Tree, label::AbstractString) = (t.label = label)

--- a/src/reading.jl
+++ b/src/reading.jl
@@ -78,7 +78,7 @@ function parse_newick_string(
 	@assert nw[end] == ';' "Newick string does not end with ';'"
 
 	reset_n()
-	root = parse_newick(nw; node_data_type)
+	root = parse_newick(nw[1:end-1]; node_data_type)
 	tree = node2tree(root; force_new_labels)
 	check_tree(tree)
 	return tree

--- a/test/iterators/test.jl
+++ b/test/iterators/test.jl
@@ -4,7 +4,7 @@ using TreeTools
 println("##### iterators #####")
 
 begin
-	nwk = "(((A1:1,A2:1,B:1,C:1)i_2:0.5,(D1:0,D2:0)i_3:1.5)i_1:1,(E:1.5,(F:1.0,(G:0.,H:0.)i_6:0.5)i_5:1)i_4:1)i_r"
+	nwk = "(((A1:1,A2:1,B:1,C:1)i_2:0.5,(D1:0,D2:0)i_3:1.5)i_1:1,(E:1.5,(F:1.0,(G:0.,H:0.)i_6:0.5)i_5:1)i_4:1)i_r;"
 	tree = parse_newick_string(nwk)
 	tnodes = sort(["A1", "A2", "B", "C", "i_2", "D1", "D2", "i_3", "i_1", "E", "F", "G", "H", "i_6", "i_5", "i_4", "i_r"])
 	tleaves = sort(["A1", "A2", "B", "C", "D1", "D2", "E", "F", "G", "H"])

--- a/test/methods/test.jl
+++ b/test/methods/test.jl
@@ -84,7 +84,7 @@ end
 	@test typeof(convert(Tree{TreeTools.EmptyData}, t2)) == Tree{TreeTools.EmptyData}
 end
 
-nwk = "(A:3,(B:1,C:1):2)"
+nwk = "(A:3,(B:1,C:1):2);"
 @testset "Distance" begin
 	t = parse_newick_string(nwk)
 	# Branch length


### PR DESCRIPTION
- `label` must be a `String`. By default, it is a `randstring(10)`
- `label(t::Tree)` returns the label
- `label!(t::Tree, label)` to set a label