### PR TITLE
Sort nodes in alphabetical order if same rank in mcc

### DIFF
--- a/src/methods.jl
+++ b/src/methods.jl
@@ -476,17 +476,23 @@ Ladderize `t` by placing nodes with largest clades left in the newick string.
 """
 ladderize!(t::Tree) = ladderize!(t.root)
 function ladderize!(n::TreeNode)
+	function _isless(v1::Tuple{Int, String}, v2::Tuple{Int, String})
+		if (v1[1] < v2[1]) || (v1[1] == v2[1] && v1[2] < v2[2])
+			return true
+		else 
+			return false
+		end
+	end
 	if n.isleaf
-		return 1
+		return (1, n.label)
 	else
-		rank = zeros(Int, length(n.child))
+		rank = Array{Any}(undef, length(n.child))
 		for (k, c) in enumerate(n.child)
 			rank[k] = ladderize!(c)
 		end
+		n.child = n.child[sortperm(rank; lt= _isless)]
 
-		n.child = n.child[sortperm(rank; rev=false)]
-
-		return sum(rank)
+		return sum([r[1] for r in rank]), n.label
 	end
 
 	return nothing

--- a/src/methods.jl
+++ b/src/methods.jl
@@ -484,7 +484,7 @@ function ladderize!(n::TreeNode)
 			rank[k] = ladderize!(c)
 		end
 
-		n.child = n.child[reverse(sortperm(rank; rev=true))]
+		n.child = n.child[sortperm(rank; rev=false)]
 
 		return sum(rank)
 	end

--- a/test/methods/test.jl
+++ b/test/methods/test.jl
@@ -138,3 +138,9 @@ nwk = "((A,B),(D,(E,F,G)));"
 	@test tmp == sort(["A", "NODE_2", "E", "F", "NODE_4", "NODE_3"])
 	@test isempty(TreeTools.branches_in_spanning_tree(t, "E"))
 end
+
+@testset "ladderize alphabetically" begin
+	t1 = node2tree(TreeTools.parse_newick("((D,A,B),C)"; node_data_type=TreeTools.MiscData); label="t1")
+	TreeTools.ladderize!(t1)
+	@test write_newick(t1) == "(C,(A,B,D)NODE_2)NODE_1:0;"
+end


### PR DESCRIPTION
This is more just a pet-peeve and not that important. Currently, the `ladderize!` command will change the order of leaves in mcc clades if they have the same rank in the tree, which is quite confusing. For example: 
`nwk_1 = "(A,(B,C,D,E))"`
will become 
`nwk_1_ladderize_output= "(A,(E,D,C,B))"`
after calling `ladderize!` on the tree. 

I found this quite confusing. I initially just wanted nodes to stay the same as in input order but think it might be even nicer if we are anyways sorting them to sort the nodes of same rank in a polytomy by alphabetical order. 

I have added a small test. Additionally, I tested it on the NY data set in `TreeKnit` to make sure this works on large trees. 