### PR TITLE
Reorganize write functions

### DIFF
--- a/src/TreeTools.jl
+++ b/src/TreeTools.jl
@@ -10,7 +10,7 @@ import Base: eachindex, firstindex, get!, getindex, lastindex, setindex!
 ## Others
 import Base: ==, cat, convert, copy, count, hash, in, intersect
 import Base: isempty, isequal, keys, map!, setdiff, show, size
-import Base: union, union!, unique, unique!
+import Base: union, union!, unique, unique!, write
 
 ##
 include("objects.jl")
@@ -30,7 +30,7 @@ include("reading.jl")
 export parse_newick_string, read_tree
 
 include("writing.jl")
-export write_newick, write_fasta
+export write_newick, write_fasta, newick
 
 include("misc.jl")
 export print_tree, check_tree, print_tree_ascii

--- a/src/TreeTools.jl
+++ b/src/TreeTools.jl
@@ -30,7 +30,7 @@ include("reading.jl")
 export parse_newick_string, read_tree
 
 include("writing.jl")
-export write_newick, write_fasta, newick
+export write_newick, newick
 
 include("misc.jl")
 export print_tree, check_tree, print_tree_ascii


### PR DESCRIPTION
We now have the following: 
- Overload of `write` 
```
write(io::IO, t::Tree; style=:newick)
write(filename::AbstractString, t::Tree, mode="w"; style=:newick)
```
This adds the possibility to implement other styles (JSON?)
- we still have `write_newick`, which does not take the `style` kwarg and potentially returns the newick string: 
```
write_newick(tree::Tree) # returns a string
write_newick(io::IO, tree::Tree) # writes to IO
write_newick(filename::AbstractString, tree::Tree, mode="w") # writes to file 
```
- we have the `newick` function which always returns a newick string and can also be called on `TreeNode`: 
```
newick(t::Tree) # returns a string
newick(n::TreeNode)
```