### PR TITLE
Functions for pangraph

### DIFF
--- a/src/TreeTools.jl
+++ b/src/TreeTools.jl
@@ -15,7 +15,7 @@ import Base: union, union!, unique, unique!, write
 ##
 include("objects.jl")
 export Tree, TreeNode, TreeNodeData, MiscData
-export isleaf, isroot, ancestor, children, branch_length, label, label!
+export isleaf, isroot, ancestor, children, branch_length, branch_length!, label, label!
 
 include("methods.jl")
 export lca, node2tree, node2tree!, node_depth, distance, divtime, share_labels

--- a/src/objects.jl
+++ b/src/objects.jl
@@ -129,4 +129,29 @@ Base.in(n::TreeNode, t::Tree; exclude_internals=false) = in(n.label, t; exclude_
 Base.getindex(t::Tree, label) = getindex(t.lnodes, label)
 
 label(t::Tree) = t.label
+"""
+	label!(t::Tree, label::AbstractString)
+
+Change the label of the `Tree` to `label`.
+"""
 label!(t::Tree, label::AbstractString) = (t.label = string(label))
+"""
+	label!(t::Tree, node::TreeNode, new_label::AbstractString)
+	label!(t::Tree, old_label, new_label)
+
+Change the label of a `TreeNode` to `new_label`.
+"""
+function label!(tree::Tree, node::TreeNode, label::AbstractString)
+	@assert in(node, tree) "Node $(node.label) is not in tree."
+	@assert !in(label, tree) "Node $(label) is already in tree: can't rename $(node.label) like this."
+	tree.lnodes[label] = node
+	delete!(tree.lnodes, node.label)
+	if node.isleaf
+		tree.lleaves[label] = node
+		delete!(tree.lleaves, node.label)
+	end
+	node.label = label
+
+	return nothing
+end
+label!(t::Tree, old_label, new_label) = label!(t, t[old_label], new_label)

--- a/src/objects.jl
+++ b/src/objects.jl
@@ -97,6 +97,7 @@ Base.hash(x::TreeNode, h::UInt) = hash(x.label, h)
 children(n::TreeNode) = n.child
 ancestor(n::TreeNode) = n.anc
 branch_length(n::TreeNode) = n.tau
+branch_length!(n::TreeNode, τ::Union{Missing, Real}) = (n.tau = τ)
 label(n::TreeNode) = n.label
 isleaf(n) = n.isleaf
 isroot(n) = n.isroot
@@ -128,4 +129,4 @@ Base.in(n::TreeNode, t::Tree; exclude_internals=false) = in(n.label, t; exclude_
 Base.getindex(t::Tree, label) = getindex(t.lnodes, label)
 
 label(t::Tree) = t.label
-label!(t::Tree, label::AbstractString) = (t.label = label)
+label!(t::Tree, label::AbstractString) = (t.label = string(label))

--- a/src/writing.jl
+++ b/src/writing.jl
@@ -1,62 +1,72 @@
 const write_styles = (:newick)
 
 """
-	write(io::IO, t::Tree; style=:newick)
-	write(filename::AbstractString, t::Tree, mode="w"; style=:newick)
+	write(io::IO, t::Tree; style=:newick, internal_labels=true)
+	write(filename::AbstractString, t::Tree, mode="w"; style=:newick, internal_labels=true)
 
-Write `t` to file or IO with format determined by `style`.
+Write `t` to file or IO with format determined by `style`. If `internal_labels == false`,
+do not write labels of internal nodes in the string.
 """
-function write(io::IO, t::Tree; style=:newick)
+function write(io::IO, t::Tree; style=:newick, internal_labels=true)
 	return if style in (:newick, :Newick, "newick", "Newick")
-		write_newick(io, t)
+		write_newick(io, t; internal_labels)
 	else
 		@error "Unknown write style $style. Allowed: $(write_styles)."
 		error()
 	end
 end
-function write(filename::AbstractString, t::Tree, mode="w"; style=:newick)
+function write(
+	filename::AbstractString, t::Tree, mode="w";
+	style=:newick, internal_labels=true
+)
 	return open(filename, mode) do io
-		write(io, t; style)
+		write(io, t; style, internal_labels)
 	end
 end
 
 """
-	write_newick(io::IO, tree::Tree)
-	write_newick(filename::AbstractString, tree::Tree, mode="w")
-	write_newick(tree::Tree)
+	write_newick(io::IO, tree::Tree; internal_labels=true)
+	write_newick(filename::AbstractString, tree::Tree, mode="w"; internal_labels=true)
+	write_newick(tree::Tree; internal_labels=true)
 
 Write Newick string corresponding to `tree` to `io` or `filename`. If output is not
-provided, return the Newick string.
+provided, return the Newick string. If `internal_labels == false`, do not
+write labels of internal nodes in the string.
 """
-write_newick(io::IO, tree::Tree) = write(io, newick(tree))
-function write_newick(filename::AbstractString, tree::Tree, mode="w")
+function write_newick(io::IO, tree::Tree; internal_labels=true)
+	return write(io, newick(tree; internal_labels))
+end
+function write_newick(filename::AbstractString, tree::Tree, mode="w"; internal_labels=true)
 	return open(filename, mode) do io
-		write_newick(io, tree)
+		write_newick(io, tree; internal_labels)
 	end
 end
 
 """
-	newick(tree::Tree)
+	newick(tree::Tree; internal_labels=true)
 
-Return the Newick string correpsonding to `tree`.
+Return the Newick string correpsonding to `tree`. If `internal_labels == false`, do not
+write labels of internal nodes in the string.
 """
-newick(tree::Tree) = newick(tree.root)
-write_newick(tree::Tree) = newick(tree)
+newick(tree::Tree; internal_labels=true) = newick(tree.root; internal_labels)
+write_newick(tree::Tree; internal_labels=true) = newick(tree; internal_labels)
 
 
-newick(root::TreeNode) = _newick!("", root)*";"
-function _newick!(s::String, root::TreeNode)
+newick(root::TreeNode; internal_labels = true) = _newick!("", root, internal_labels)*";"
+function _newick!(s::String, root::TreeNode, internal_labels)
 	if !isempty(root.child)
 		s *= '('
 		# temp = sort(root.child, by=x->length(POTleaves(x)))
 		for c in root.child
-			s = _newick!(s, c)
+			s = _newick!(s, c, internal_labels)
 			s *= ','
 		end
 		s = s[1:end-1] # Removing trailing ','
 		s *= ')'
 	end
-	s *= root.label
+	if isleaf(root) || internal_labels
+		s *= root.label
+	end
 	if !ismissing(root.tau)
 		s *= ':'
 		s *= string(root.tau)

--- a/test/methods/test.jl
+++ b/test/methods/test.jl
@@ -146,16 +146,31 @@ end
 end
 
 
-nwk = "(A,(B,C,D,E,(F,G,H)));"
-@testset "binarize" begin
-	t = parse_newick_string(nwk)
-	TreeTools.rand_times!(t)
+@testset "Binarize" begin
 	bl(t) = sum(skipmissing(map(x -> x.tau, nodes(t)))) # branch length should stay unchanged
-	L = bl(t)
-	z = TreeTools.binarize!(t; mode=:balanced)
-	@test z == 4
-	@test length(SplitList(t)) == 7
-	@test bl(t) == L
+
+	nwk = "(A,(B,C,D,E,(F,G,H)));"
+	@testset "1" begin
+		t = parse_newick_string(nwk)
+		TreeTools.rand_times!(t)
+		L = bl(t)
+		z = TreeTools.binarize!(t; mode=:balanced)
+		@test z == 4
+		@test length(SplitList(t)) == 7
+		@test bl(t) == L
+	end
+
+	nwk = "(8:571.0,(((10:0.0,17:0.0)internal_1:12.8,(12:0.0,19:0.0)internal_2:12.5)internal_11:80.7,((6:26.3,(4:0.0,5:0.0)internal_7:22.0)internal_14:22.4,(1:12.5,3:12.5)internal_10:36.1,((11:0.0,20:0.0)internal_5:16.5,7:11.2,16:11.2,9:0.0,13:0.0,18:0.0,15:0.0)internal_13:23.1,(2:0.0,14:0.0)internal_4:42.1)internal_17:43.0)internal_18:477.0)internal_19:0;"
+	@testset "2" begin
+		t = parse_newick_string(nwk)
+		L = bl(t)
+		z = TreeTools.binarize!(t; mode=:balanced)
+		@test length(nodes(t)) == 2*length(leaves(t)) - 1
+		for n in nodes(t)
+			@test length(children(n)) == 2 || isleaf(n)
+		end
+	end
+
 end
 
 

--- a/test/methods/test.jl
+++ b/test/methods/test.jl
@@ -230,6 +230,25 @@ end
 		d2 = TreeTools.distance_to_deepest_leaf(t.root.child[2]; topological=false) + t.root.child[2].tau
 		@test isapprox(d1, d2, rtol = 1e-10)
 	end
+
+
+	# Some sick tree by Marco
+	@testset "5" begin
+		nwk = "(A:0.0,B:0.0,C:0.0,D:0.0,E:0.0,F:0.0,G:0.0,H:0.0,I:0.0,J:0.0)ROOT;"
+		t = parse_newick_string(nwk)
+		@test_logs (:warn, r"") match_mode=:any TreeTools.root!(t; method=:midpoint) # should warn and do nothing
+		@test label(t.root) == "ROOT"
+
+		TreeTools.root!(t; method=:midpoint, topological=true) # should do nothing since root is already midpoint
+		@test label(t.root) == "ROOT"
+
+		branch_length!(t["A"], 1.)
+		TreeTools.root!(t; method=:midpoint)
+		@test length(children(t.root)) == 2
+		@test in(t["A"], children(t.root))
+	end
+
+
 end
 
 

--- a/test/methods/test.jl
+++ b/test/methods/test.jl
@@ -176,38 +176,45 @@ end
 
 
 @testset "Midpoint rooting" begin
-	nwk = "(A,(B,(C,(D,(E,F)))));"
 	@testset "1" begin
+		nwk = "(A,(B,(C,(D,(E,F)))));"
 		t = parse_newick_string(nwk)
 		TreeTools.rand_times!(t)
 		TreeTools.root!(t, method=:midpoint, topological=true)
-		@test t["C"].anc == t.root
 		for n in nodes(t)
 			@test (n.isroot && ismissing(branch_length(n))) || (!n.isroot && !ismissing(branch_length(n)))
 		end
+		@test length(children(t.root)) == 2
+		d1 = TreeTools.distance_to_deepest_leaf(t.root.child[1]; topological=true) + 1
+		d2 = TreeTools.distance_to_deepest_leaf(t.root.child[2]; topological=true) + 1
+		@test d1 == d2 || abs(d1-d2) == 1
 	end
 
-	nwk = "(A,(B,(C,(D,E))));"
+
 	@testset "2" begin
+		nwk = "(A,(B,(C,(D,E))));"
 		t = parse_newick_string(nwk)
 		TreeTools.rand_times!(t)
 		TreeTools.root!(t, method=:midpoint, topological=true)
-		@test t["C"].anc.anc == t.root
 		for n in nodes(t)
 			@test (n.isroot && ismissing(branch_length(n))) || (!n.isroot && !ismissing(branch_length(n)))
 		end
-		@test distance(t.root, t["A"]; topological=true) == 2 || distance(t.root, t["D"]; topological=true) == 2
+		@test length(children(t.root)) == 2
+		d1 = TreeTools.distance_to_deepest_leaf(t.root.child[1]; topological=true) + 1
+		d2 = TreeTools.distance_to_deepest_leaf(t.root.child[2]; topological=true) + 1
+		@test d1 == d2 || abs(d1-d2) == 1
 	end
 
 
-	nwk = "(A,((B,(C,D)),E,F,(G,(H,I))));"
 	@testset "3" begin
-		t = parse_newick_string(nwk)
+		nwk = "(A,((B,(C,D)),E,F,(G,(H,I))));"
+		t = parse_newick_string(nwk);
 		TreeTools.rand_times!(t)
 		TreeTools.root!(t, method = :midpoint)
-		@test t["A"].anc == t.root
-		@test t["E"].anc == t.root
-		@test t["F"].anc == t.root
+		@test length(children(t.root)) == 2
+		d1 = TreeTools.distance_to_deepest_leaf(t.root.child[1]; topological=false) + t.root.child[1].tau
+		d2 = TreeTools.distance_to_deepest_leaf(t.root.child[2]; topological=false) + t.root.child[2].tau
+		@test isapprox(d1, d2, rtol = 1e-10)
 	end
 
 	# Some Kingman tree
@@ -218,6 +225,10 @@ end
 		for n in nodes(t)
 			@test isroot(n) || !ismissing(branch_length(n))
 		end
+		@test length(children(t.root)) == 2
+		d1 = TreeTools.distance_to_deepest_leaf(t.root.child[1]; topological=false) + t.root.child[1].tau
+		d2 = TreeTools.distance_to_deepest_leaf(t.root.child[2]; topological=false) + t.root.child[2].tau
+		@test isapprox(d1, d2, rtol = 1e-10)
 	end
 end
 

--- a/test/methods/test.jl
+++ b/test/methods/test.jl
@@ -168,7 +168,7 @@ end
 		TreeTools.root!(t, method=:midpoint, topological=true)
 		@test t["C"].anc == t.root
 		for n in nodes(t)
-			@test (n.isroot && ismissing(n.tau)) || (!n.isroot && !ismissing(n.tau))
+			@test (n.isroot && ismissing(branch_length(n))) || (!n.isroot && !ismissing(branch_length(n)))
 		end
 	end
 
@@ -179,20 +179,30 @@ end
 		TreeTools.root!(t, method=:midpoint, topological=true)
 		@test t["C"].anc.anc == t.root
 		for n in nodes(t)
-			@test (n.isroot && ismissing(n.tau)) || (!n.isroot && !ismissing(n.tau))
+			@test (n.isroot && ismissing(branch_length(n))) || (!n.isroot && !ismissing(branch_length(n)))
 		end
 		@test distance(t.root, t["A"]; topological=true) == 2 || distance(t.root, t["D"]; topological=true) == 2
 	end
 
 
 	nwk = "(A,((B,(C,D)),E,F,(G,(H,I))));"
-	@testset "2" begin
+	@testset "3" begin
 		t = parse_newick_string(nwk)
 		TreeTools.rand_times!(t)
 		TreeTools.root!(t, method = :midpoint)
 		@test t["A"].anc == t.root
 		@test t["E"].anc == t.root
 		@test t["F"].anc == t.root
+	end
+
+	# Some Kingman tree
+	nwk = "((3:42.39239447896236,9:42.39239447896236)internal_7:184.59454190028205,(((7:5.386265198881789,(4:3.4161799796066714,6:3.4161799796066714)internal_1:1.970085219275118)internal_3:13.350057070009068,(2:5.857739627778067,5:5.857739627778067)internal_4:12.878582641112791)internal_5:27.712331677710498,(10:33.43880444968331,(1:4.740041795143892,8:4.740041795143892)internal_2:28.69876265453942)internal_6:13.009849496918044)internal_8:180.53828243264306)internal_9:0;"
+	@testset "4" begin
+		t = parse_newick_string(nwk)
+		TreeTools.root!(t; method=:midpoint)
+		for n in nodes(t)
+			@test isroot(n) || !ismissing(branch_length(n))
+		end
 	end
 end
 

--- a/test/objects/test.jl
+++ b/test/objects/test.jl
@@ -1,0 +1,22 @@
+println("##### objects #####")
+
+using TreeTools
+using Test
+
+@testset "Node relabel" begin
+	nwk = "(A,(B,C));"
+	t = parse_newick_string(nwk)
+	label!(t, t["A"], "D")
+	@test check_tree(t)
+	@test !in("A", t)
+	@test in("D", t)
+	@test length(nodes(t)) == 5
+	labels = map(label, POT(t))
+	@test !in("A", labels)
+	@test in("D", labels)
+	@test sort(labels) == sort(collect(keys(t.lnodes)))
+
+	@test_throws AssertionError label!(t, t["D"], "B")
+	@test_throws AssertionError label!(t, "D", "B")
+end
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using TreeTools
 
 include("$(dirname(pathof(TreeTools)))/../test/reading/test.jl")
+include("$(dirname(pathof(TreeTools)))/../test/objects/test.jl")
 include("$(dirname(pathof(TreeTools)))/../test/methods/test.jl")
 include("$(dirname(pathof(TreeTools)))/../test/prunegraft/test.jl")
 include("$(dirname(pathof(TreeTools)))/../test/iterators/test.jl")


### PR DESCRIPTION
Functions needed for usage in PanGraph. 

New stuff:
- `label!(t::Tree, node::TreeNode, new_label)` to safely relabel tree nodes
- `branch_length!(node::TreeNode, value)` to set branch length
- kwarg `internal_labels` to allow not writing labels of internal nodes in a Newick string. Defaults to `true`. 
- `binarize!` and midpoint rooting functions (actually added in an earlier PR)
- reorganize write functions a bit