### PR TITLE
Dev/reorganize prune graft

### DIFF
--- a/src/TreeTools.jl
+++ b/src/TreeTools.jl
@@ -8,7 +8,7 @@ import Base: eltype, iterate, IteratorEltype, IteratorSize, length
 import Base: eachindex, firstindex, get!, getindex, lastindex, setindex!
 
 ## Others
-import Base: ==, cat, convert, copy, count, hash, in, intersect
+import Base: ==, cat, convert, copy, count, delete!, hash, in, insert!, intersect
 import Base: isempty, isequal, keys, map!, setdiff, show, size
 import Base: union, union!, unique, unique!, write
 
@@ -24,7 +24,7 @@ include("iterators.jl")
 export POT, POTleaves, nodes, leaves, internals
 
 include("prunegraft.jl")
-export graft!, prune!, delete_node!, prunesubtree!
+export graft!, prune!, prunesubtree!
 
 include("reading.jl")
 export parse_newick_string, read_tree

--- a/src/TreeTools.jl
+++ b/src/TreeTools.jl
@@ -24,7 +24,7 @@ include("iterators.jl")
 export POT, POTleaves, nodes, leaves, internals
 
 include("prunegraft.jl")
-export delete_node!, graftnode!, prunenode!, prunenode, prunesubtree!
+export graft!, prune!, delete_node!, prunesubtree!
 
 include("reading.jl")
 export parse_newick_string, read_tree

--- a/src/methods.jl
+++ b/src/methods.jl
@@ -94,6 +94,7 @@ If label is of one of these forms and followed by a string of the form `__NAME`,
 parsed.
 """
 function parse_bootstrap(label::AbstractString)
+	@warn "`parse_bootstrap` is not implemented yet, doing nothing and return `missing`."
 	return missing
 end
 

--- a/src/methods.jl
+++ b/src/methods.jl
@@ -624,7 +624,8 @@ function root_midpoint!(t::Tree; topological = false)
 		end
 		@assert ismissing(τ) || 0 <= τ <= b_l.tau "Issue with time on the branch above midpoint"
 
-		R = add_internal_singleton!(b_l, b_h, τ, make_random_label("MIDPOINT_ROOT"))
+		# R = add_internal_singleton!(b_l, b_h, τ, make_random_label("MIDPOINT_ROOT"))
+		R = insert!(t, b_l; time=τ, name=get_unique_label(t, "MIDPOINT_ROOT"))
 		node2tree!(t, t.root)
 
 		@debug "Introducing new root between $(b_l.label) and $(b_h.label)"

--- a/src/misc.jl
+++ b/src/misc.jl
@@ -214,11 +214,26 @@ end
 
 default_tree_label(n=10) = randstring(n)
 
-make_random_label(base="NODE") = make_random_label(base, 8)
-make_random_label(base, i) = "$(base)_$(randstring(i))"
+make_random_label(base="NODE"; delim = "_") = make_random_label(base, 8; delim)
+make_random_label(base, i; delim = "_") = base * delim * randstring(i)
+
+function get_unique_label(t::Tree, base = "NODE"; delim = "_")
+	label = make_random_label(base; delim)
+	while haskey(t.lnodes, label)
+		label = make_random_label(base; delim)
+	end
+	return label
+end
+
+function set_unique_label!(node::TreeNode, t::Tree; delim = "_")
+	base = label(node)
+	new_label = get_unique_label(t, base; delim)
+	node.label = new_label
+end
 
 """
     create_label(t::Tree, base="NODE")
+
 Create new node label in tree `t` with format `\$(base)_i` with `i::Int`.
 """
 function create_label(t::Tree, base="NODE")
@@ -232,16 +247,12 @@ function create_label(t::Tree, base="NODE")
     return "$(base)_$(label_init)"
 end
 
-function set_unique_label!(node::TreeNode, t::Tree; delim = "__")
-	id = randstring(8)
-	node.label *= delim * id
-	while haskey(t.lnodes, node.label)
-		node.label = node.label[1:end-5] * randstring(8)
-	end
-end
+
+
 
 """
     map_dict_to_tree!(t::Tree{MiscData}, dat::Dict; symbol=false, key = nothing)
+
 Map data in `dat` to nodes of `t`. All node labels of `t` should be keys of `dat`. Entries of `dat` should be dictionaries, or iterable similarly, and are added to `n.data.dat`.
 If `!isnothing(key)`, only a specific key of `dat` is added. It's checked for by `k == key || Symbol(k) == key` for all keys `k` of `dat`.
 If `symbol`, data is added to nodes of `t` with symbols as keys.

--- a/src/misc.jl
+++ b/src/misc.jl
@@ -177,7 +177,7 @@ function check_tree(tree::Tree; strict=true)
     labellist = Dict{String, Int64}()
     nroot = 0
     flag = true
-    for n in values(tree.lnodes)
+    for n in nodes(tree)
         if !n.isleaf && length(n.child)==0
         	(flag = false) || (@warn "Node $(n.label) is non-leaf and has no child.")
         elseif !n.isroot && n.anc == nothing

--- a/src/prunegraft.jl
+++ b/src/prunegraft.jl
@@ -137,9 +137,9 @@ None of the nodes of the subtree of `n` should belong to `tree`.
 If `r` is a leaf and `graft_on_leaf` is set to `false` (default), will raise an error.
 """
 function graft!(
-	t::Tree, n::TreeNode, r::TreeNode;
+	t::Tree{T}, n::TreeNode{T}, r::TreeNode;
 	graft_on_leaf=false, tau = branch_length(n),
-)
+) where T
 	# checks
 	if !graft_on_leaf && isleaf(r)
 		error("Cannot graft: node $r is a leaf (got `graft_on_leaf=false`")
@@ -168,6 +168,13 @@ function graft!(
 
 	return nothing
 end
+function graft!(t::Tree{T}, n::TreeNode{R}, r::TreeNode; kwargs...) where T where R
+	error(
+		"Cannot graft node of type $(typeof(n)) on tree of type $(typeof(t)).
+		Try to change node data type"
+	)
+end
+
 graft!(t, n::TreeNode, r::AbstractString; kwargs...) = graft!(t, n, t[r]; kwargs...)
 graft!(t1, t2::Tree, r; kwargs...) = graft!(t1, copy(t2).root, r; kwargs...)
 
@@ -228,7 +235,7 @@ end
 """
 Insert `s` between `a` and `c` at height `t`: `a --> s -- t --> c`
 """
-function _insert_node!(c::TreeNode, a::TreeNode, s::TreeNode, t::Missing)
+function _insert_node!(c::TreeNode{T}, a::TreeNode{T}, s::TreeNode{T}, t::Missing) where T
 	@assert ancestor(c) == a
 	@assert ismissing(branch_length(c))
 	@assert ismissing(branch_length(a))
@@ -239,7 +246,7 @@ function _insert_node!(c::TreeNode, a::TreeNode, s::TreeNode, t::Missing)
 	graftnode!(s, c)
 	return nothing
 end
-function _insert_node!(c::TreeNode, a::TreeNode, s::TreeNode, t::Number)
+function _insert_node!(c::TreeNode{T}, a::TreeNode{T}, s::TreeNode{T}, t::Number) where T
 	@assert ancestor(c) == a
 	@assert branch_length(s) == branch_length(c) - t
 	@assert branch_length(c) >= t
@@ -259,11 +266,11 @@ Insert a singleton named `name` above `node`, at height `time` on the branch.
 `time` can be a `Number` or `missing`.
 """
 function insert!(
-	t::Tree,
+	t::Tree{T},
 	n::TreeNode;
 	name = get_unique_label(t),
 	time = zero(branch_length(n)),
-)
+) where T
 
 	# Checks
 	nτ = branch_length(n)
@@ -277,7 +284,7 @@ function insert!(
 
 	#
 	sτ = nτ - time
-	s = TreeNode(; label=name, tau = sτ)
+	s = TreeNode(; label=name, tau = sτ, data = T())
 	_insert_node!(n, ancestor(n), s, time)
 	t.lnodes[name] = s
 

--- a/src/prunegraft.jl
+++ b/src/prunegraft.jl
@@ -1,12 +1,12 @@
 """
 	prunenode!(node::TreeNode)
 
-Prune node `node` by detaching it from its ancestor. Return pruned `node` and its previous
-  ancestor.
+Prune node `node` by detaching it from its ancestor.
+Return pruned `node` and its previous ancestor.
 """
 function prunenode!(node::TreeNode)
 	if node.isroot
-		@warn "Trying to prune root: no op."
+		@warn "Trying to prune root: aborting"
 		return node, TreeNode()
 	end
 	anc = node.anc
@@ -27,11 +27,13 @@ end
 """
 	prunenode(node::TreeNode)
 
-Prune node `node` by detaching it from its ancestor. Return pruned `node` and previous root `r`. The tree defined by `node` is copied before the operation, and therefore not modified.
+Prune node `node` by detaching it from its ancestor.
+Return pruned `node` and previous root `r`.
+The tree defined by `node` is copied before the operation and is not modified.
 """
 function prunenode(node::TreeNode)
 	if node.isroot
-		@warn "Trying to prune root: no op."
+		@warn "Trying to prune root: aborting"
 		node_ = deepcopy(node)
 		return node_, node_
 	end
@@ -49,13 +51,30 @@ function prunenode(node::TreeNode)
 	return node_, r
 end
 
+"""
+	graftnode!(r::TreeNode, n::TreeNode ; tau=n.tau)
+
+Graft `n` on `r`.
+"""
+function graftnode!(r::TreeNode, n::TreeNode; tau=n.tau)
+	if !n.isroot || n.anc != nothing
+		@error "Trying to graft non-root node $(n)."
+	end
+	push!(r.child, n)
+	r.isleaf = false
+	n.anc = r
+	n.isroot = false
+	n.tau = tau
+	return nothing
+end
+
 
 """
 	prunesubtree!(tree, r::TreeNode)
 	prunesubtree!(tree, labellist)
 
 Prune and subtree corresponding to the MRCA of labels in `labellist`.
-  Return the root of the subtree as well as its previous direct ancestor.
+Return the root of the subtree as a `TreeNode` as well as its previous direct ancestor.
 """
 function prunesubtree!(tree, labellist; clade_only=true)
 	if clade_only && !isclade(labellist, tree)
@@ -85,58 +104,146 @@ function prunesubtree!(tree, r::TreeNode; remove_singletons=true)
 	return r, a
 end
 
-"""
-	remove_internal_singletons!(tree; ptau=true)
+function prune!(t, r; return_tree=true, kwargs...)
+	r, a = prunesubtree!(t, r; kwargs...)
+	return return_tree ? node2tree(r) : r
+end
 
-Remove nodes with one child. Root node is left as is.
-If `ptau`, the length of branches above removed nodes is added to the branch length above their children.
+
 """
-function remove_internal_singletons!(tree; ptau=true)
-	root = tree.root
-	for n in values(tree.lnodes)
-		if length(n.child) == 1
-			if !n.isroot
-				delete_node!(n, ptau=ptau)
-				delete!(tree.lnodes, n.label)
-			end
+	graft!(tree::Tree, n, r; graft_on_leaf=false)
+
+Graft `n` onto `r`.
+`r` can be a label or a `TreeNode`, and should belong to `tree`.
+`n` can be a node label, a `TreeNode`, or a `Tree`.
+In the latter case, `n` will be *copied* before being grafted.
+None of the nodes of the subtree of `n` should belong to `tree`.
+
+If `r` is a leaf and `graft_on_leaf` is set to `false` (default), will raise an error.
+"""
+function graft!(
+	t::Tree, n::TreeNode, r::TreeNode;
+	graft_on_leaf=false, tau = branch_length(n),
+)
+	# checks
+	if !graft_on_leaf && isleaf(r)
+		error("Cannot graft: node $r is a leaf (got `graft_on_leaf=false`")
+	elseif !isroot(n) && !isnothing(ancestor(n))
+		error("Cannot graft non-root node $(label(n))")
+	end
+
+	# checking that the subtree defined by `n` is not in `t`
+	for c in POT(n)
+		if in(c, t)
+			error("Cannot graft: some nodes in subtree of $(label(n)) are already part of tree $(label(t))")
 		end
 	end
-	# If root itself is a singleton, delete its child and regraft onto it.
-	if length(tree.root.child) == 1 && !tree.root.child[1].isleaf
-		n = tree.root.child[1]
-		delete_node!(n, ptau=ptau)
-		delete!(tree.lnodes, n.label)
+
+	# Handling tree dicts
+	isleaf(r) && delete!(t.lleaves, label(r))
+	for c in POT(n)
+		t.lnodes[label(c)] = c
+		if isleaf(c)
+			t.lleaves[label(c)] = c
+		end
 	end
-	#
-	#node2tree!(tree, root)
-end
 
+	# grafting
+	graftnode!(r, n; tau)
 
-"""
-	graftnode!(r::TreeNode, n::TreeNode ; tau=n.tau)
-
-Graft `n` on `r`.
-"""
-function graftnode!(r::TreeNode, n::TreeNode ; tau=n.tau)
-	if !n.isroot || n.anc != nothing
-		@error "Trying to graft non-root node $(n)."
-	end
-	push!(r.child, n)
-	r.isleaf = false
-	n.anc = r
-	n.isroot = false
-	n.tau = tau
 	return nothing
 end
+graft!(t, n::TreeNode, r::AbstractString; kwargs...) = graft!(t, n, t[r]; kwargs...)
+graft!(t1, t2::Tree, r; kwargs...) = graft!(t1, copy(t2).root, r; kwargs...)
+
+
+function subtree_prune_regraft!(
+	t::Tree, p::AbstractString, g::AbstractString;
+	remove_singletons = true, graft_on_leaf = false, create_new_leaf = false,
+)
+	# Checks
+	if !create_new_leaf && length(children(ancestor(t[p]))) == 1
+		error("Cannot prune node $p without creating a new leaf (got `create_new_leaf=false`)")
+	elseif !graft_on_leaf && isleaf(t[g])
+		error("Cannot graft: node $g is a leaf (got `graft_on_leaf=false`")
+	end
+
+	# prune
+	n, a = prunenode!(t[p])
+	if isleaf(a)
+		t.lleaves[label(a)] = a
+	end
+
+	# graft
+	if isleaf(g)
+		delete!(t.lleaves, g)
+	end
+	graft!(t, n, g)
+
+	return nothing
+end
+
+
+"""
+	add_internal_singleton!(n::TreeNode, a::TreeNode, τ::Real)
+
+Add internal singleton above `n` and below `a`, at heigh `τ` above `n`.
+Return the singleton.
+"""
+function add_internal_singleton!(n::TreeNode, a::TreeNode, τ::Real, label; v = false)
+	# Branch length above n and above the singleton
+	nτ, sτ = n.tau >= τ ? (τ, n.tau - τ) : (n.tau, 0.)
+
+	s = TreeNode(; tau = sτ, label)
+	prunenode!(n)
+	n.tau = nτ
+	graftnode!(a, s)
+	graftnode!(s, n)
+	return s
+end
+function add_internal_singleton!(n::TreeNode, a::TreeNode, τ::Missing, label; v = false)
+	@assert ismissing(n.tau)
+	prunenode!(n)
+	s = TreeNode(; label)
+	graftnode!(a, s)
+	graftnode!(s, n)
+	return s
+end
+
+# function insert_node!(n::TreeNode, label, tau = zero(branch_length(n)))
+# 	nτ = branch_length(n)
+# 	if ismissing(nτ) != ismissing(tau) || tau > nτ
+# 		error("Cannot insert node at height $tau on branch with length $nτ")
+# 	end
+
+# 	# Branch length above n and above the singleton
+# 	# ancestor(n) -- τ2 --> s -- tau --> n
+# 	τ2 = nτ - tau
+# 	s = TreeNode(; tau = tau, label)
+
+# end
+
+# """
+# 	insert_node!(t::Tree, n::AbstractString; tau = 0.)
+
+# Insert a node on the branch above `n`, at distance `tau` from `n`.
+# """
+# function insert_node!(t::Tree, n::AbstractString; tau = 0.)
+
+# end
+
+
+
 
 """
 	delete_node!(node::TreeNode; ptau=false)
 
-Delete `node`. If it is an internal node, its children are regrafted on `node.anc`. Returns the new `node.anc`.  
-If `ptau`, branch length above `node` is added to the regrafted branch. 
+Delete `node`. If it is an internal node, its children are regrafted on `node.anc`.
+Returns the new `node.anc`.
+If `ptau`, branch length above `node` is added to the regrafted branch.
 Otherwise, the regrafted branch's length is unchanged. Return modified `node.anc`.
 
-Note that the previous node will still be in the dictionary `lnodes` and `lleaves` (if a leaf) and the print function will fail on the tree, 
+Note that the previous node will still be in the dictionary `lnodes` and `lleaves` (if a leaf) and the print function will fail on the tree,
 to fully remove from the tree and apply the print function use `delete_node!(t::Tree, label; ptau=false)`
 """
 function delete_node!(node::TreeNode; ptau=false)
@@ -214,29 +321,32 @@ function delete_branches!(f, tree::Tree; keep_time=false)
 	return nothing
 end
 
-"""
-	add_internal_singleton!(n::TreeNode, a::TreeNode, τ::Real)
 
-Add internal singleton above `n` and below `a`, at heigh `τ` above `n`.
-Return the singleton.
 """
-function add_internal_singleton!(n::TreeNode, a::TreeNode, τ::Real, label; v = false)
-	# Branch length above n and above the singleton
-	nτ, sτ = n.tau >= τ ? (τ, n.tau - τ) : (n.tau, 0.)
+	remove_internal_singletons!(tree; ptau=true)
 
-	s = TreeNode(; tau = sτ, label)
-	prunenode!(n)
-	n.tau = nτ
-	graftnode!(a, s)
-	graftnode!(s, n)
-	return s
+Remove nodes with one child. Root node is left as is.
+If `ptau`, the length of branches above removed nodes is added to the branch length above
+their children.
+"""
+function remove_internal_singletons!(tree; ptau=true)
+	root = tree.root
+	for n in values(tree.lnodes)
+		if length(n.child) == 1
+			if !n.isroot
+				delete_node!(n, ptau=ptau)
+				delete!(tree.lnodes, n.label)
+			end
+		end
+	end
+	# If root itself is a singleton, delete its child and regraft onto it.
+	if length(tree.root.child) == 1 && !tree.root.child[1].isleaf
+		n = tree.root.child[1]
+		delete_node!(n, ptau=ptau)
+		delete!(tree.lnodes, n.label)
+	end
+	#
+	#node2tree!(tree, root)
 end
-function add_internal_singleton!(n::TreeNode, a::TreeNode, τ::Missing, label; v = false)
-	@assert ismissing(n.tau)
-	prunenode!(n)
-	s = TreeNode(; label)
-	graftnode!(a, s)
-	graftnode!(s, n)
-	return s
-end
+
 

--- a/src/prunegraft.jl
+++ b/src/prunegraft.jl
@@ -207,31 +207,31 @@ function __subtree_prune_regraft!(
 end
 
 
-"""
-	add_internal_singleton!(n::TreeNode, a::TreeNode, τ::Real)
+# """
+# 	add_internal_singleton!(n::TreeNode, a::TreeNode, τ::Real)
 
-Add internal singleton above `n` and below `a`, at heigh `τ` above `n`.
-Return the singleton.
-"""
-function add_internal_singleton!(n::TreeNode, a::TreeNode, τ::Real, label)
-	# Branch length above n and above the singleton
-	nτ, sτ = n.tau >= τ ? (τ, n.tau - τ) : (n.tau, 0.)
+# Add internal singleton above `n` and below `a`, at heigh `τ` above `n`.
+# Return the singleton.
+# """
+# function add_internal_singleton!(n::TreeNode, a::TreeNode, τ::Real, label)
+# 	# Branch length above n and above the singleton
+# 	nτ, sτ = n.tau >= τ ? (τ, n.tau - τ) : (n.tau, 0.)
 
-	s = TreeNode(; tau = sτ, label)
-	prunenode!(n)
-	n.tau = nτ
-	graftnode!(a, s)
-	graftnode!(s, n)
-	return s
-end
-function add_internal_singleton!(n::TreeNode, a::TreeNode, τ::Missing, label)
-	@assert ismissing(n.tau)
-	prunenode!(n)
-	s = TreeNode(; label)
-	graftnode!(a, s)
-	graftnode!(s, n)
-	return s
-end
+# 	s = TreeNode(; tau = sτ, label)
+# 	prunenode!(n)
+# 	n.tau = nτ
+# 	graftnode!(a, s)
+# 	graftnode!(s, n)
+# 	return s
+# end
+# function add_internal_singleton!(n::TreeNode, a::TreeNode, τ::Missing, label)
+# 	@assert ismissing(n.tau)
+# 	prunenode!(n)
+# 	s = TreeNode(; label)
+# 	graftnode!(a, s)
+# 	graftnode!(s, n)
+# 	return s
+# end
 """
 Insert `s` between `a` and `c` at height `t`: `a --> s -- t --> c`
 """
@@ -263,6 +263,7 @@ end
 	insert_node!(tree, node; name, time)
 
 Insert a singleton named `name` above `node`, at height `time` on the branch.
+Return the inserted singleton.
 `time` can be a `Number` or `missing`.
 """
 function insert!(

--- a/src/prunegraft.jl
+++ b/src/prunegraft.jl
@@ -110,7 +110,8 @@ end
 
 Prune `node` from `tree`.
 `node` can be a label or a `TreeNode`.
-Return the subtree defined by `node` as a `Tree` object.
+Return the subtree defined by `node` as a `Tree` object as well as the previous
+ancestor of `node`.
 
 If a list of labels is provided, the MRCA of the corresponding nodes is pruned.
 
@@ -120,7 +121,7 @@ If a list of labels is provided, the MRCA of the corresponding nodes is pruned.
 """
 function prune!(t, r; kwargs...)
 	r, a = prunesubtree!(t, r; kwargs...)
-	return node2tree(r)
+	return node2tree(r), a
 end
 
 

--- a/src/reading.jl
+++ b/src/reading.jl
@@ -76,14 +76,16 @@ Parse newick string into a tree. See `read_tree` for more informations.
 function parse_newick_string(
 	nw::AbstractString;
 	node_data_type=DEFAULT_NODE_DATATYPE, 
-	label=default_tree_label(), force_new_labels=false,
+	label=default_tree_label(),
+	force_new_labels=false,
+	strict_check = true,
 )
 	@assert nw[end] == ';' "Newick string does not end with ';'"
 
 	reset_n()
 	root = parse_newick(nw[1:end-1]; node_data_type)
 	tree = node2tree(root; label, force_new_labels)
-	check_tree(tree)
+	check_tree(tree, strict = strict_check)
 	return tree
 end
 

--- a/test/iterators/test.jl
+++ b/test/iterators/test.jl
@@ -1,7 +1,7 @@
 using Test
 using TreeTools
 
-println("##### iterators #####")
+# println("##### iterators #####")
 
 begin
 	nwk = "(((A1:1,A2:1,B:1,C:1)i_2:0.5,(D1:0,D2:0)i_3:1.5)i_1:1,(E:1.5,(F:1.0,(G:0.,H:0.)i_6:0.5)i_5:1)i_4:1)i_r;"

--- a/test/methods/test.jl
+++ b/test/methods/test.jl
@@ -1,4 +1,4 @@
-println("##### methods #####")
+# println("##### methods #####")
 
 using Test
 using TreeTools
@@ -251,31 +251,30 @@ end
 
 end
 
-println("##### Tree Measures #####")
+@testset "Tree measures" begin
+	nwk1 = "((A,B),C);"
+	nwk2 = "(A,(B,C));"
+	nwk3 = "((A,B,D),C);"
+	nwk4 = "(((A,B),D),C);"
 
-nwk1 = "((A,B),C);"
-nwk2 = "(A,(B,C));"
-nwk3 = "((A,B,D),C);"
-nwk4 = "(((A,B),D),C);"
+	t1 = node2tree(TreeTools.parse_newick(nwk1), label = "a")
+	t2 = node2tree(TreeTools.parse_newick(nwk2), label = "b")
+	t3 = node2tree(TreeTools.parse_newick(nwk3), label = "c")
+	t4 = node2tree(TreeTools.parse_newick(nwk4), label = "d")
 
-t1 = node2tree(TreeTools.parse_newick(nwk1), label = "a")
-t2 = node2tree(TreeTools.parse_newick(nwk2), label = "b")
-t3 = node2tree(TreeTools.parse_newick(nwk3), label = "c")
-t4 = node2tree(TreeTools.parse_newick(nwk4), label = "d")
+	@testset "RF distance" begin
+		@test TreeTools.RF_distance(t1, t2) == 2
+	    @test TreeTools.RF_distance(t3, t4) == 1
+	    @test TreeTools.RF_distance(t1, t2; scale=true) == 1
+	    @test TreeTools.RF_distance(t3, t4; scale=true) == 1/3
+	    @test_throws AssertionError TreeTools.RF_distance(t1, t3)
+	end
 
-@testset "RF distance" begin
-	@test TreeTools.RF_distance(t1, t2) == 2
-    @test TreeTools.RF_distance(t3, t4) == 1
-    @test TreeTools.RF_distance(t1, t2; scale=true) == 1
-    @test TreeTools.RF_distance(t3, t4; scale=true) == 1/3
-    @test_throws AssertionError TreeTools.RF_distance(t1, t3)
+	@testset "resolution value" begin
+		@test TreeTools.resolution_value(t3) == (2/3)
+	    @test TreeTools.resolution_value(t4) == 1
+	end
 end
-
-@testset "resolution value" begin
-	@test TreeTools.resolution_value(t3) == (2/3)
-    @test TreeTools.resolution_value(t4) == 1
-end
-
 
 
 

--- a/test/objects/test.jl
+++ b/test/objects/test.jl
@@ -1,4 +1,4 @@
-println("##### objects #####")
+# println("##### objects #####")
 
 using TreeTools
 using Test

--- a/test/prunegraft/test.jl
+++ b/test/prunegraft/test.jl
@@ -1,33 +1,77 @@
 using Test
 using TreeTools
 
-println("##### prunegraft #####")
-global root_1 = TreeTools.read_newick("$(dirname(pathof(TreeTools)))/../test/prunegraft/tree1.nwk")
+
+@testset "TreeNode level functions" begin
+	root_1 = TreeTools.read_newick("$(dirname(pathof(TreeTools)))/../test/prunegraft/tree1.nwk")
+
+	@testset "Pruning (node)" begin
+		# Pruning with modification
+		root = deepcopy(root_1)
+		global A = TreeTools.prunenode!(root.child[1].child[1])[1]
+		root_ref = TreeTools.read_newick("$(dirname(pathof(TreeTools)))/../test/prunegraft/tree1_Apruned.nwk")
+	    @test root == root_ref
+	    # Pruning with copy
+		root = deepcopy(root_1)
+		global A2 = TreeTools.prunenode(root.child[1].child[1])[1]
+		@test root == root_1 && A == A2
+	end
+
+
+	@testset "Grafting (node)" begin
+		root = deepcopy(root_1)
+		A = TreeTools.prunenode!(root.child[1].child[1])[1]
+		TreeTools.graftnode!(root.child[2].child[1], A);
+		@test root == TreeTools.read_newick("$(dirname(pathof(TreeTools)))/../test/prunegraft/tree_grafttest1.nwk")
+	end
+
+	@testset "Deleting" begin
+		root = deepcopy(root_1)
+		temp = delete_node!(root.child[1])
+		@test temp == root && root == TreeTools.read_newick("$(dirname(pathof(TreeTools)))/../test/prunegraft/tree_del1.nwk")
+	end
+end
+
+
+@testset "Grafting new node onto tree" begin
+	nwk = "((A:1,B:1)AB:2,(C:1,D:1)CD:2)R;"
+	t = parse_newick_string(nwk)
+
+	# 1
+	E = TreeNode(label = "E", tau = 4.)
+	tc = copy(t)
+	graft!(tc, E, "AB")
+	@test sort(map(label, children(tc["AB"]))) == ["A","B","E"]
+	@test ancestor(E) == tc["AB"]
+	@test in(E, tc)
+	@test in(E, children(tc["AB"]))
+	@test branch_length(E) == 4
+	@test_throws ErrorException graft!(tc, E, "CD") # E is not a root anymore
+
+	# 2
+	E = TreeNode(label = "E", tau = 5.)
+	tc = copy(t)
+	@test_throws ErrorException graft!(tc, E, tc["A"])
+	graft!(tc, E, tc["A"], graft_on_leaf=true, tau = 1.)
+	@test !isleaf(tc["A"])
+	@test ancestor(E) == tc["A"]
+	@test in(E, tc)
+	@test in(E, children(tc["A"]))
+	@test branch_length(E) == 1
+
+	# 3
+	E = node2tree(TreeNode(label = "E", tau = 5.))
+	tc = copy(t)
+	graft!(tc, E, "AB") # will copy E
+	@test sort(map(label, children(tc["AB"]))) == ["A","B","E"]
+	@test isnothing(ancestor(E.root))
+	@test check_tree(E)
+	@test in("E", tc)
+	@test in("E", map(label, children(tc["AB"])))
+	@test_throws ErrorException graft!(tc, E, "CD")
+end
+
 @testset "Pruning" begin
-	# Pruning with modification
-	root = deepcopy(root_1)
-	global A = prunenode!(root.child[1].child[1])[1]
-	root_ref = TreeTools.read_newick("$(dirname(pathof(TreeTools)))/../test/prunegraft/tree1_Apruned.nwk")
-    @test root == root_ref
-    # Pruning with copy
-	root = deepcopy(root_1)
-	global A2 = prunenode(root.child[1].child[1])[1]
-	@test root == root_1 && A == A2
-end
-
-
-@testset "Grafting" begin
-	root = deepcopy(root_1)
-	A = prunenode!(root.child[1].child[1])[1]
-	graftnode!(root.child[2].child[1], A);
-	@test root == TreeTools.read_newick("$(dirname(pathof(TreeTools)))/../test/prunegraft/tree_grafttest1.nwk")
-end
-
-
-@testset "Deleting" begin
-	root = deepcopy(root_1)
-	temp = delete_node!(root.child[1])
-	@test temp == root && root == TreeTools.read_newick("$(dirname(pathof(TreeTools)))/../test/prunegraft/tree_del1.nwk")
 end
 
 @testset "Deleting branches" begin

--- a/test/prunegraft/test.jl
+++ b/test/prunegraft/test.jl
@@ -96,7 +96,7 @@ end
 
 	# 3
 	tc = copy(t)
-	tp = prune!(tc, ["A","B"]; remove_singletons = false)
+	tp, _ = prune!(tc, ["A","B"]; remove_singletons = false)
 	@test !in("AB", tc)
 	@test !in("A", tc)
 	@test in("AB", tp)
@@ -105,8 +105,8 @@ end
 	@test sort(map(label, children(tc.root))) == ["CD"]
 
 	# 4
-	t = parse_newick_string("(A,(B,(C,(D))));")
-	tp = prune!(t, ["B","D"], clade_only=false)
+	t = parse_newick_string("(A,(B,(C,D)));")
+	tp, _ = prune!(t, ["B","D"], clade_only=false)
 	@test length(leaves(t)) == 1
 	@test length(leaves(tp)) == 3
 	@test sort(map(label, leaves(tp))) == ["B","C","D"]

--- a/test/prunegraft/test.jl
+++ b/test/prunegraft/test.jl
@@ -35,7 +35,7 @@ end
 
 @testset "Grafting new node onto tree" begin
 	nwk = "((A:1,B:1)AB:2,(C:1,D:1)CD:2)R;"
-	t = parse_newick_string(nwk)
+	t = parse_newick_string(nwk; node_data_type = TreeTools.EmptyData)
 
 	# 1
 	E = TreeNode(label = "E", tau = 4.)
@@ -68,11 +68,20 @@ end
 	@test check_tree(E)
 	@test in("E", tc)
 	@test_throws ErrorException graft!(tc, E, "CD")
+
+	# 4
+	E = TreeNode(label = "E", tau = 4., data = MiscData())
+	tc = copy(t)
+	@test_throws ErrorException graft!(tc, E, "AB")
+
+	tc = convert(Tree{MiscData}, t)
+	E = TreeNode(label = "E", tau = 4.)
+	@test_throws ErrorException graft!(tc, E, "AB")
 end
 
 @testset "Pruning" begin
 	nwk = "((A:1,B:1)AB:2,(C:1,D:1)CD:2)R;"
-	t = parse_newick_string(nwk)
+	t = parse_newick_string(nwk; node_data_type = TreeTools.EmptyData)
 
 	# 1
 	tc = copy(t)
@@ -114,7 +123,7 @@ end
 
 @testset "Insert" begin
 	nwk = "((A:1,B:1)AB:2,(C:1,D:1)CD:2)R;"
-	t = parse_newick_string(nwk)
+	t = parse_newick_string(nwk; node_data_type = TreeTools.EmptyData)
 
 	# 1
 	tc = copy(t)
@@ -124,7 +133,7 @@ end
 	@test_throws ErrorException insert!(tc, "R"; time = 1.)
 
 	# 2
-	tc = copy(t)
+	tc = convert(Tree{MiscData}, t)
 	s = insert!(tc, "A"; time = 0.25)
 	@test in(label(s), tc)
 	@test ancestor(tc["A"]) == s
@@ -132,11 +141,24 @@ end
 	@test ancestor(s) == t["AB"]
 	@test branch_length(s) == 0.75
 	@test branch_length(s) + branch_length(tc["A"]) == 1.
+
+	# 3
+	tc = convert(Tree{MiscData}, t)
+	s = insert!(tc, "A"; time = 0.25)
+	@test typeof(s) == TreeNode{MiscData}
+	@test in(label(s), tc)
+	@test ancestor(tc["A"]) == s
+	@test map(label, children(s)) == ["A"]
+	@test ancestor(s) == t["AB"]
+	@test branch_length(s) == 0.75
+	@test branch_length(s) + branch_length(tc["A"]) == 1.
+	s.data["Hello"] = " World!"
+	@test tc[s.label].data["Hello"] == " World!"
 end
 
 @testset "Delete" begin
 	nwk = "((A:1,B:1)AB:2,(C:1,D:1)CD:2)R;"
-	t = parse_newick_string(nwk)
+	t = parse_newick_string(nwk; node_data_type = TreeTools.EmptyData)
 
 	# 1
 	tc = copy(t)

--- a/test/reading/test.jl
+++ b/test/reading/test.jl
@@ -1,4 +1,4 @@
-println("##### reading #####")
+# println("##### reading #####")
 
 using Test
 using TreeTools

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,18 +2,34 @@ using TreeTools
 using Test
 
 @testset verbose=true "TreeTools" begin
+	@testset "Reading" begin
+		println("## Reading")
+		include("$(dirname(pathof(TreeTools)))/../test/reading/test.jl")
+	end
 
-	include("$(dirname(pathof(TreeTools)))/../test/reading/test.jl")
-	include("$(dirname(pathof(TreeTools)))/../test/objects/test.jl")
-	include("$(dirname(pathof(TreeTools)))/../test/methods/test.jl")
+	@testset "Objects" begin
+		println("## Objects")
+		include("$(dirname(pathof(TreeTools)))/../test/objects/test.jl")
+	end
+
+	@testset "Methods" begin
+		println("## Methods")
+		include("$(dirname(pathof(TreeTools)))/../test/methods/test.jl")
+	end
 
 	@testset "Prune/Graft" begin
 		println("## Prune/Graft")
 		include("prunegraft/test.jl")
 	end
 
-	include("$(dirname(pathof(TreeTools)))/../test/iterators/test.jl")
-	include("$(dirname(pathof(TreeTools)))/../test/splits/test.jl")
+	@testset "Iterators" begin
+		println("## Iterators")
+		include("$(dirname(pathof(TreeTools)))/../test/iterators/test.jl")
+	end
 
+	@testset "Splits" begin
+		println("## Splits")
+		include("$(dirname(pathof(TreeTools)))/../test/splits/test.jl")
+	end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
 using TreeTools
+using Test
 
 @testset verbose=true "TreeTools" begin
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,9 +1,18 @@
 using TreeTools
 
-include("$(dirname(pathof(TreeTools)))/../test/reading/test.jl")
-include("$(dirname(pathof(TreeTools)))/../test/objects/test.jl")
-include("$(dirname(pathof(TreeTools)))/../test/methods/test.jl")
-include("$(dirname(pathof(TreeTools)))/../test/prunegraft/test.jl")
-include("$(dirname(pathof(TreeTools)))/../test/iterators/test.jl")
-include("$(dirname(pathof(TreeTools)))/../test/splits/test.jl")
+@testset verbose=true "TreeTools" begin
+
+	include("$(dirname(pathof(TreeTools)))/../test/reading/test.jl")
+	include("$(dirname(pathof(TreeTools)))/../test/objects/test.jl")
+	include("$(dirname(pathof(TreeTools)))/../test/methods/test.jl")
+
+	@testset "Prune/Graft" begin
+		println("## Prune/Graft")
+		include("prunegraft/test.jl")
+	end
+
+	include("$(dirname(pathof(TreeTools)))/../test/iterators/test.jl")
+	include("$(dirname(pathof(TreeTools)))/../test/splits/test.jl")
+
+end
 

--- a/test/splits/test.jl
+++ b/test/splits/test.jl
@@ -1,7 +1,7 @@
 using Test
 using TreeTools
 
-println("##### splits #####")
+# println("##### splits #####")
 
 nwk1 = "(((A1,A2),(B1,B2),(C1,C2)),D,E)"
 t = node2tree(TreeTools.parse_newick(nwk1)) #


### PR DESCRIPTION
`Tree` level functions for pruning and grafting. Node level functions are not exported. 
Not exported anymore
- `prunenode!`
- `graftnode!`
- `delete_node!`

New exported methods
- `prune!`
- `graft!`
- `insert!`
- `delete!`

Removed
- `add_internal_singleton!` remplaced by `insert!`. 

