### PR TITLE
Implement copy methods for TreeNodeData

### DIFF
--- a/src/methods.jl
+++ b/src/methods.jl
@@ -228,7 +228,7 @@ function _copy!(an::TreeNode{T}, n::TreeNode, i) where T <: TreeNodeData
 
 	return nothing
 end
-_copy_data(::Type{T}, n::TreeNode{T}) where T <: TreeNodeData = deepcopy(n.data)
+_copy_data(::Type{T}, n::TreeNode{T}) where T <: TreeNodeData = copy(n.data)
 _copy_data(::Type{T}, n::TreeNode) where T <: TreeNodeData = T()
 
 """

--- a/src/objects.jl
+++ b/src/objects.jl
@@ -9,6 +9,8 @@ Implemented concrete types are
 """
 abstract type TreeNodeData end
 
+Base.copy(x::TreeNodeData) = deepcopy(x)
+
 """
 	struct MiscData <: TreeNodeData
 		dat::Dict{Any,Any}
@@ -32,11 +34,14 @@ Base.get!(d::MiscData, k, v) = get!(d.dat, k, v)
 
 Base.haskey(d::MiscData, k) = haskey(d.dat, k)
 
+Base.copy(d::MiscData) = MiscData(copy(d.dat))
+
 """
 	struct EmptyData <: TreeNodeData
 """
 struct EmptyData <: TreeNodeData
 end
+Base.copy(::EmptyData) = EmptyData()
 
 const DEFAULT_NODE_DATATYPE = EmptyData
 


### PR DESCRIPTION
- calls `Base.copy` for `MiscData` and `EmptyData`
- falls back to `deepcopy` if no other method is specified

For custom `TreeNodeData`, implementing a specialized `copy` will be faster