### PR TITLE
Rooting from model

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@latest
         with:
-          version: '1.6'
+          version: '1.7'
       - name: Install dependencies
         run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
       - name: Build and deploy

--- a/src/methods.jl
+++ b/src/methods.jl
@@ -685,7 +685,7 @@ function root_like_model!(tree, model::Tree)
     R, time = if !isroot(A1) && !isroot(A2)
         # if none of them is the root, then `tree` is already rooted correctly
         if SplitList(model) != SplitList(tree)
-            warn_1()
+            @warn "Tree and model differ too much for rooting. Leaving input tree unchanged."
         end
         return nothing
     elseif isroot(A1) && isroot(A2)

--- a/src/methods.jl
+++ b/src/methods.jl
@@ -675,9 +675,7 @@ function root_like_model!(tree, model::Tree)
 
     R, time = if !isroot(A1) && !isroot(A2)
         # if none of them is the root, then `tree` is already rooted correctly
-        Smodel = SplitList(model)
-        Stree = SplitList(tree)
-        if any(s -> !in(s, Smodel), Stree) || any(s -> !in(s, Stree), Smodel)
+        if SplitList(model) != SplitList(tree)
             @warn "Trees differ by more than rooting. Check what you're doing."
         end
         return nothing
@@ -694,9 +692,7 @@ function root_like_model!(tree, model::Tree)
     end
     TreeTools.root!(tree, R; time)
 
-    Smodel = SplitList(model)
-    Stree = SplitList(tree)
-    if any(s -> !in(s, Smodel), Stree) || any(s -> !in(s, Stree), Smodel)
+    if SplitList(model) != SplitList(tree)
         @warn "Trees differ by more than rooting. Check what you're doing."
     end
 

--- a/src/splits.jl
+++ b/src/splits.jl
@@ -1,3 +1,7 @@
+#############################################################
+########################### Split ###########################
+#############################################################
+
 """
 	Split
 
@@ -207,6 +211,10 @@ function are_disjoint(s::Split, t::Split, mask)
 	return true
 end
 
+#############################################################
+######################### SplitList #########################
+#############################################################
+
 """
 	SplitList{T}
 
@@ -393,9 +401,11 @@ function _splitlist!(S::SplitList, r::TreeNode, leafmap::Dict)
 end
 
 function Base.show(io::IO, S::SplitList)
+    println(io, "SplitList of $(length(S)) splits")
+    max_i = 20
 	for (i,s) in enumerate(S)
-		if i > 20
-			println(io, "...")
+		if i > max_i
+			println(io, "... ($(length(S)-max_i) more)")
 			break
 		end
 		println(io, leaves(S,i))
@@ -653,3 +663,10 @@ function clean!(
 	deleteat!(S.splits, idx)
 end
 
+#############################################################
+####################### Indexing Tree #######################
+#############################################################
+
+function Base.getindex(tree::Tree, S::SplitList, i::Int)
+    return lca(tree, leaves(S, i)...)
+end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,3 +1,4 @@
 [deps]
 Chain = "8be319e6-bccf-4806-a6f7-6fae938471bc"
+Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/methods/test.jl
+++ b/test/methods/test.jl
@@ -287,6 +287,17 @@ end
     nwk = "(A:1,((D:2,(C:3,E:1):2):2,B:0.5):1);"
     tree = parse_newick_string(nwk)
     @test_logs (:warn,) TreeTools.root!(tree; method=:model, model)
+
+    nwk = "((A:1,C:1):1,(B:2,(C:3,E:1):2):2);"
+    @test_logs (:warn,) TreeTools.root!(tree; method=:model, model)
+
+    # Test with missing branch lengths
+    model_nwk = "((A,B),(C,(D,E)));"
+    model = parse_newick_string(model_nwk)
+
+    tree = copy(model)
+    TreeTools.root!(tree, lca(tree, "D", "E").label, time = missing)
+    @test_logs min_level=Logging.Warn TreeTools.root!(tree; method=:model, model)
 end
 
 

--- a/test/methods/test.jl
+++ b/test/methods/test.jl
@@ -2,6 +2,7 @@
 
 using Test
 using TreeTools
+using Logging
 
 
 ## Testing equality operator
@@ -265,9 +266,29 @@ end
 		@test length(children(t.root)) == 2
 		@test in(t["A"], children(t.root))
 	end
-
-
 end
+
+@testset "Model rooting" begin
+    model_nwk = "((A:1,B:1):1,(C:2,(D:3,E:1):2):2);"
+    model = parse_newick_string(model_nwk)
+
+    tree = copy(model)
+    TreeTools.root!(tree, lca(tree, "D", "E").label, time = 1)
+    @test_logs min_level=Logging.Warn TreeTools.root!(tree; method=:model, model)
+
+    tree = copy(model)
+    TreeTools.root!(tree, "A", time = .5)
+    @test_logs min_level=Logging.Warn TreeTools.root!(tree; method=:model, model)
+
+    nwk = "((A:1,B:1):1,(D:2,(C:3,E:1):2):2);"
+    tree = parse_newick_string(nwk)
+    @test_logs (:warn,) TreeTools.root!(tree; method=:model, model)
+
+    nwk = "(A:1,((D:2,(C:3,E:1):2):2,B:0.5):1);"
+    tree = parse_newick_string(nwk)
+    @test_logs (:warn,) TreeTools.root!(tree; method=:model, model)
+end
+
 
 @testset "Tree measures" begin
 	nwk1 = "((A,B),C);"

--- a/test/methods/test.jl
+++ b/test/methods/test.jl
@@ -191,7 +191,9 @@ end
     @test tree["B"] |> ancestor |> isroot
     @test pw_distances == [distance(tree, x, y) for x in leaf_labels for y in leaf_labels]
 
-    @test_throws ErrorException TreeTools.root!(tree, "B"; time = 5)
+    @test_throws ErrorException redirect_stderr(
+        () -> TreeTools.root!(tree, "B"; time = 5), devnull
+    )
 end
 
 @testset "Midpoint rooting" begin


### PR DESCRIPTION
Add method to root a tree using another as a model. 
Signature: `root_like_model!(tree, model::Tree)`. 
Behavior: 
- root `tree` in such a way as to make identical to `model` (topologically)
- if this is not possible (the two trees are different), two scenarios
  * if the two trees are not too dissimilar (*i.e.* the rooting algorithm still found a sensible root for `tree`), then `tree` is re-rooted and a warning is given
  * if the two trees are too different, `tree` is left unchanged and a warning is given
 