### PR TITLE
Rework traversal functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ docs/Manifest.toml
 # environment.
 Manifest.toml
 
+examples/_scrap
+examples/test_iterators
+

--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,8 @@ version = "0.6.14"
 
 [deps]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+ResumableFunctions = "c5292f4c-5179-55e1-98c5-05642aab7184"
 
 [compat]
+ResumableFunctions = "0.6.10"
 julia = "1.7"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+TreeTools = "62f0eae3-8c0e-4032-a621-7756092209e5"
 
 [compat]
 Documenter = "0.27"

--- a/src/TreeTools.jl
+++ b/src/TreeTools.jl
@@ -1,6 +1,7 @@
 module TreeTools
 
 using Random
+using ResumableFunctions
 
 ## Iteration
 import Base: eltype, iterate, IteratorEltype, IteratorSize, length
@@ -24,7 +25,10 @@ export lca, node2tree, node2tree!, node_depth, distance, divtime, share_labels, 
 export root!
 
 include("iterators.jl")
-export POT, POTleaves, nodes, leaves, internals
+export nodes, leaves, internals
+export traversal, postorder_traversal
+
+# include("better_iterators.jl")
 
 include("prunegraft.jl")
 export insert!, graft!, prune!, prunesubtree!

--- a/src/TreeTools.jl
+++ b/src/TreeTools.jl
@@ -27,6 +27,7 @@ export root!
 include("iterators.jl")
 export nodes, leaves, internals
 export traversal, postorder_traversal
+export POT, POTleaves # for backward compat
 
 # include("better_iterators.jl")
 

--- a/src/iterators.jl
+++ b/src/iterators.jl
@@ -1,3 +1,7 @@
+#===================================================#
+################## Arbitrary order ##################
+#===================================================#
+
 """
 	nodes(t; skiproot=false)
 	leaves(t)
@@ -31,126 +35,116 @@ end
 nodes(f::Function, t::Tree) = filter(f, values(t.lnodes))
 
 
-#=
-Post order traversal iterators
-=#
-abstract type POTIterator end
-
-Base.IteratorSize(::Type{POTIterator}) = Iterators.HasLength()
-Base.IteratorEltype(::Type{POTIterator}) = HasEltype()
-
-Base.iterate(itr::POTIterator) = firststate(itr, itr.root)
+#=============================================================================#
+########################## Post-order (leaves first) ##########################
+#=============================================================================#
 
 """
-	struct POT{T<:TreeNodeData} <: POTIterator
-		root::TreeNode{T}
-	end
+    postorder_traversal([f], tree; root=true, leaves=true, internals=true)
+
+Traverse `tree` in postorder, iterating over nodes.
+The children of `node` are returned in the same order as `children(node)`.
+
+Keep only nodes `n` such that `f(n)` is true.
+If `leaves`, `internals` or `root` are set to `false`, the corresponding nodes are excluded.
+
+## Examples
+```julia
+for node in postorder_traversal(tree; root=false)
+    isroot(node) # always false
+end
+
+[label(x) for x in postorder_traversal(tree; internals=false)] # labels of leaf nodes
+```
 """
-struct POT{T<:TreeNodeData} <: POTIterator
-	root::TreeNode{T}
+function postorder_traversal(
+    f::Function, node::TreeNode; root=true, leaves=true, internals=true,
+)
+    function _f(n)
+        if !root && isroot(n)
+            return false
+        end
+        if !internals && isinternal(n)
+            return false
+        end
+        if !leaves && isleaf(n)
+            return false
+        end
+        if !f(n)
+            return false
+        end
+        return true
+    end
+    return _POT(_f, node)
 end
-Base.eltype(::Type{POT{T}}) where T = TreeNode{T}
-POT(t::Tree) = POT(t.root)
-function Base.length(iter::POT)
-	return count(x->true, iter.root)
+postorder_traversal(f, tree::Tree; kwargs...) = postorder_traversal(f, root(tree); kwargs...)
+postorder_traversal(tree; kwargs...) = postorder_traversal(x -> true, tree; kwargs...)
+
+@resumable function _POT(node::TreeNode{T}) where T
+    stack = TreeNode{T}[node]
+    isempty(stack) && return nothing
+    head = stack[end]
+    while !isempty(stack)
+        next = stack[end]
+        # Main.@infiltrate
+        if next.isleaf || _subtrees_visited(next, head)
+            head = next
+            pop!(stack)
+            @yield next
+        else
+            for c in Iterators.reverse(children(next))
+                push!(stack, c)
+            end
+        end
+    end
+    return nothing
+end
+@resumable function _POT(filter_func, node::TreeNode{T}) where T
+    stack = TreeNode{T}[node]
+    isempty(stack) && return nothing
+    head = stack[end]
+    while !isempty(stack)
+        next = stack[end]
+        # Main.@infiltrate
+        if next.isleaf || _subtrees_visited(next, head)
+            head = next
+            pop!(stack)
+            if filter_func(next)
+                @yield next
+            end
+        else
+            for c in Iterators.reverse(children(next))
+                push!(stack, c)
+            end
+        end
+    end
+    return nothing
 end
 
-"""
-	struct POTleaves{T<:TreeNodeData} <: POTIterator
-		root::TreeNode{T}
-	end
-"""
-struct POTleaves{T<:TreeNodeData} <: POTIterator
-	root::TreeNode{T}
-end
-Base.eltype(::Type{POTleaves{T}}) where T = TreeNode{T}
-POTleaves(t::Tree) = POTleaves(t.root)
-function Base.length(iter::POTleaves)
-	return count(isleaf, iter.root)
+function _subtrees_visited(next, head)
+    for c in children(next)
+        if c === head
+            return true
+        end
+    end
+    return false
 end
 
-struct POTState{T<:TreeNodeData}
-	n::TreeNode{T}
-	i::Int # Position of n in list of siblings -- `n.anc.child[i]==n`
-	direction::Symbol
+#=============================================#
+################ Traversal hub ################
+#=============================================#
+
+
+const traversal_styles = Dict(:postorder => postorder_traversal)
+function traversal(f, tree::Tree, style::Symbol; kwargs...)
+    if haskey(traversal_styles, style)
+        return traversal_styles[style](f, tree; kwargs...)
+    else
+        throw(ArgumentError("""
+        traversal style must be in $(collect(keys(traversal_styles))). Instead $style.
+        """))
+    end
 end
-
-
-"""
-- `state.n.isleaf`: go to sibling and down or ancestor and up (stop if root)
-- Otherwise: go to deepest child and up.
-"""
-function Base.iterate(itr::POTIterator, state::POTState)
-	if state.direction == :down
-		return go_down(itr, state)
-	elseif state.direction == :up
-		return go_up(itr, state)
-	elseif state.direction == :stop
-		return nothing
-	end
-end
-
-
-function go_down(itr::POTIterator, state::POTState{T}) where T
-	if state.n.isleaf # Go back to ancestor or sibling anyway
-		if state.n.isroot || state.n == itr.root
-			return (state.n, POTState{T}(n, 0, :stop))
-		elseif state.i < length(state.n.anc.child) # Go to sibling
-			return (state.n, POTState{T}(state.n.anc.child[state.i+1], state.i+1, :down))
-		else # Go back to ancestor
-			return (state.n, POTState{T}(state.n.anc, get_sibling_number(state.n.anc), :up))
-		end
-	end
-	return firststate(itr, state.n) # Go to deepest child of `n`
-end
-function go_up(itr::POT{T}, state::POTState{T}) where T
-	if state.n.isroot || state.n == itr.root
-		return (state.n, POTState{T}(state.n, 0, :stop))
-	elseif state.i < length(state.n.anc.child) # Go to sibling
-		return (state.n, POTState{T}(state.n.anc.child[state.i+1], state.i+1, :down))
-	else # Go back to ancestor
-		return (state.n, POTState{T}(state.n.anc, get_sibling_number(state.n.anc), :up))
-	end
-end
-function go_up(itr::POTleaves{T}, state::POTState{T}) where T
-	if state.n.isleaf
-		if state.n.isroot || state.n == itr.root
-			return (state.n, POTState{T}(state.n, 0, :stop))
-		elseif state.i < length(state.n.anc.child) # Go to sibling
-			return (state.n, POTState{T}(state.n.anc.child[state.i+1], state.i+1, :down))
-		else # Go back to ancestor
-			return (state.n, POTState{T}(state.n.anc, get_sibling_number(state.n.anc), :up))
-		end
-	else
-		if state.n.isroot || state.n == itr.root
-			return nothing
-		elseif state.i < length(state.n.anc.child) # Go to sibling
-			iterate(itr, POTState(state.n.anc.child[state.i+1], state.i+1, :down))
-		else # Go back to ancestor
-			iterate(itr, POTState(state.n.anc, get_sibling_number(state.n.anc), :up))
-		end
-	end
-end
-
-
-"""
-Go to deepest child of `a`.
-"""
-function firststate(itr::POTIterator, a::TreeNode{T}) where T
-	if a.isleaf
-		return iterate(itr, POTState{T}(a, 1, :up))
-	end
-	firststate(itr, a.child[1])
-end
-
-function get_sibling_number(n::TreeNode)
-	if n.isroot
-		return 0
-	end
-	for (i,c) in enumerate(n.anc.child)
-		if n == c
-			return i
-		end
-	end
-	@error "Could not find $(n.label) in children of $(n.anc.label)."
+function traversal(tree::Tree, style::Symbol; kwargs...)
+    return traversal(x -> true, tree, style; kwargs...)
 end

--- a/src/methods.jl
+++ b/src/methods.jl
@@ -138,11 +138,15 @@ function share_labels(tree1, tree2)
 end
 
 """
-	map(f, t::Tree)
-	map(f, r::TreeNode)
+	map(f, tree::Tree; kwargs...)
+	map(f, node::TreeNode; kwargs...)
+
+Apply `f` to each node in `tree` (or subtree of `node`). Return an array.
+Traverse the tree in post order.
+Keywords are passed to `postorder_traversal`.
 """
-Base.map(f, r::TreeNode) = map(f, POT(r))
-Base.map(f, t::Tree) = map(f, t.root)
+Base.map(f, r::TreeNode; kwargs...) = map(f, postorder_traversal(r; kwargs...))
+Base.map(f, tree::Tree; kwargs...) = map(f, root(tree); kwargs...)
 
 """
 	map!(f, t::Tree)
@@ -310,7 +314,7 @@ function isclade(nodelist; safe=true)
 	else
 		claderoot = lca(nodelist)
 		# Now, checking if `clade` is the same as `nodelist`
-		for c in POTleaves(claderoot)
+		for c in _POT(isleaf, claderoot)
 			flag = false
 			for n in nodelist
 				if n.label==c.label
@@ -481,22 +485,26 @@ end
 is_ancestor(t::Tree, a::AbstractString, n::AbstractString) = is_ancestor(t[a], t[n])
 
 """
-	distance_to_deepest_leaf(n::TreeNode; topological=false)
+	distance_to_deepest_leaf(node::TreeNode; topological=false)
 
-Distance from `n` to the deepest leaf in the clade below `n`.
+Distance from `node` to the deepest leaf in the clade below `node`.
 """
-function distance_to_deepest_leaf(n::TreeNode; topological=false)
-	return maximum(l -> distance(n, l; topological), POTleaves(n))
+function distance_to_deepest_leaf(node::TreeNode; topological=false)
+	return maximum(postorder_traversal(node; internals=false)) do leaf
+        distance(node, leaf; topological)
+    end
 end
-tree_height(tree::Tree; kwargs...) = distance_to_deepest_leaf(tree.root; kwargs...)
+tree_height(tree::Tree; kwargs...) = distance_to_deepest_leaf(root(tree); kwargs...)
 
 """
-    distance_to_shallowest_leaf(n::TreeNode; topological = false)
+    distance_to_shallowest_leaf(node::TreeNode; topological = false)
 
-Distance from `n` to the closest leaf in the clade below `n`.
+Distance from `node` to the closest leaf in the clade below `node`.
 """
-function distance_to_shallowest_leaf(n::TreeNode; topological = false)
-    return minimum(l -> distance(n, l; topological), POTleaves(n))
+function distance_to_shallowest_leaf(node::TreeNode; topological = false)
+    return minimum(postorder_traversal(node; internals=false)) do leaf
+        distance(node, leaf; topological)
+    end
 end
 
 function distance_to_closest_leaf(tree::Tree, label::AbstractString; topological = false)
@@ -676,8 +684,8 @@ function root_like_model!(tree, model::Tree)
     # Look at the two splits below the root of `model` ...
     M1 = model |> root |> children |> first
     M2 = model |> root |> children |> last
-    S1 = map(label, POTleaves(M1))
-    S2 = map(label, POTleaves(M2))
+    S1 = map(label, postorder_traversal(M1; internals=false))
+    S2 = map(label, postorder_traversal(M2; internals=false))
 
     # ... and to what nodes they correspond in `tree`
     A1 = lca(tree, S1...)
@@ -945,7 +953,7 @@ function RF_distance(t1::Tree, t2::Tree; normalize=false)
 end
 
 
-function distance_matrix(t::Tree)
+function distance_matrix(tree::Tree)
     # grossly unoptimized
-    return [distance(n, m) for n in POTleaves(t), m in POTleaves(t)]
+    return [distance(n, m) for n in leaves(tree), m in leaves(tree)]
 end

--- a/src/methods.jl
+++ b/src/methods.jl
@@ -314,10 +314,10 @@ function isclade(nodelist; safe=true)
 	else
 		claderoot = lca(nodelist)
 		# Now, checking if `clade` is the same as `nodelist`
-		for c in _POT(isleaf, claderoot)
+		for c in traversal(claderoot, :postorder, internals=false)
 			flag = false
 			for n in nodelist
-				if n.label==c.label
+				if n == c
 					flag = true
 					break
 				end

--- a/src/misc.jl
+++ b/src/misc.jl
@@ -97,17 +97,17 @@ https://github.com/biopython/biopython/blob/master/Bio/Phylo/_utils.py
 """
 function print_tree_ascii(io, t::Tree)
     column_width = 80
-    taxa = [ node.label for node in POTleaves(t)] #need leaves in Post-Order Traversal
+    taxa = [label(n) for n in postorder_traversal(t; internals=false)] # need leaves in Post-Order Traversal
     max_label_width = maximum([length(taxon) for taxon in taxa])
     drawing_width = column_width - max_label_width - 1
     drawing_height = 2 * length(taxa) - 1
 
     function get_col_positions(t::Tree)
-        depths = [divtime(node, t.root) for node in values(t.lnodes)]
+        depths = [divtime(node, root(t)) for node in nodes(t)]
         # If there are no branch lengths, assume unit branch lengths
         if ismissing(maximum(depths))
             println(io, "\n not all branch lengths known, assuming identical branch lengths")
-            depths = [node_depth(node) for node in values(t.lnodes)]
+            depths = [node_depth(node) for node in nodes(t)]
         end
         # Potential drawing overflow due to rounding -- 1 char per tree layer
         fudge_margin = max(ceil(Int, log2(length(taxa))), 1)

--- a/src/objects.jl
+++ b/src/objects.jl
@@ -104,6 +104,7 @@ Base.:(==)(x::TreeNode, y::TreeNode) = isequal(x,y)
 Base.hash(x::TreeNode, h::UInt) = hash(x.label, h)
 
 children(n::TreeNode) = n.child
+children(n::TreeNode, i::Integer) = n.child[i]
 function ancestor(n::TreeNode)
 	@assert !isroot(n) "Trying to access the ancestor of root node $(label(n))"
 	return n.anc

--- a/src/writing.jl
+++ b/src/writing.jl
@@ -77,7 +77,6 @@ end
 function _newick!(s::String, root::TreeNode, internal_labels=true, write_root=true)
 	if !isempty(root.child)
 		s *= '('
-		# temp = sort(root.child, by=x->length(POTleaves(x)))
 		for c in root.child
 			s = _newick!(s, c, internal_labels)
 			s *= ','

--- a/test/iterators/test.jl
+++ b/test/iterators/test.jl
@@ -3,31 +3,82 @@ using TreeTools
 
 # println("##### iterators #####")
 
-begin
+@testset "POT traversal" begin
 	nwk = "(((A1:1,A2:1,B:1,C:1)i_2:0.5,(D1:0,D2:0)i_3:1.5)i_1:1,(E:1.5,(F:1.0,(G:0.,H:0.)i_6:0.5)i_5:1)i_4:1)i_r;"
-	tree = parse_newick_string(nwk)
-	tnodes = sort(["A1", "A2", "B", "C", "i_2", "D1", "D2", "i_3", "i_1", "E", "F", "G", "H", "i_6", "i_5", "i_4", "i_r"])
-	tleaves = sort(["A1", "A2", "B", "C", "D1", "D2", "E", "F", "G", "H"])
+	tree = parse_newick_string(nwk);
+	node_list = sort(["A1", "A2", "B", "C", "i_2", "D1", "D2", "i_3", "i_1", "E", "F", "G", "H", "i_6", "i_5", "i_4", "i_r"])
+	leaves_list = sort(["A1", "A2", "B", "C", "D1", "D2", "E", "F", "G", "H"])
+    internals_list = sort(setdiff(node_list, leaves_list))
+    internals_noroot_list = sort(filter(!=("i_r"), internals_list))
 
-	@testset "1" begin
-		@test sort([x.label for x in POT(tree)]) == tnodes
-		@test sort([x.label for x in TreeTools.POTleaves(tree)]) == tleaves
+	@testset "Core function _POT" begin
+        R = root(tree)
+		@test sort([x.label for x in TreeTools._POT(R)]) == node_list
+		@test sort([x.label for x in TreeTools._POT(isleaf, R)]) == leaves_list
+        @test sort([x.label for x in TreeTools._POT(isinternal, R)]) == internals_list
 	end
 
-	@testset "in" begin
-		for n in nodes(tree)
-			@test in(n, tree)
-			@test in(n.label, tree)
-			if !n.isleaf
-				@test !in(n, tree; exclude_internals=true)
-			end
-		end
-	end
+    @testset "postorder_traversal: basics" begin
+        @test sort([x.label for x in postorder_traversal(root(tree))]) == node_list
+        @test sort([x.label for x in postorder_traversal(tree; leaves=false)]) == internals_list
+        @test sort([x.label for x in postorder_traversal(tree; root=false, leaves=false)]) == internals_noroot_list
+        @test isempty(sort([x.label for x in postorder_traversal(tree, leaves=false, internals=false)]))
+        iter = postorder_traversal(tree; internals=false) do node
+            label(node) != "A1"
+        end
+        @test sort([x.label for x in iter]) == leaves_list[2:end]
 
-	@testset "indexing in tree" begin
-		for n in nodes(tree)
-			@test tree[n.label] == tree.lnodes[n.label]
-		end
-		@test_throws KeyError tree["some_random_string"]
-	end
+        X = [x.label for x in postorder_traversal(isinternal, tree)]
+        Y = [x.label for x in postorder_traversal(tree; leaves=false)]
+        @test X == Y
+    end
+
+    @testset "postorder_traversal: node order" begin
+        function all_labels(node, holder = [])
+            for c in children(node)
+                all_labels(c, holder)
+            end
+            push!(holder, label(node))
+        end
+        @test [x.label for x in postorder_traversal(tree)] == all_labels(root(tree))
+        @test map(label, postorder_traversal(tree["i_2"])) == all_labels(tree["i_2"])
+    end
+
+    @testset "map - based on postorder" begin
+        function all_labels(node, holder = [])
+            for c in children(node)
+                all_labels(c, holder)
+            end
+            push!(holder, label(node))
+        end
+        @test map(label, tree) == all_labels(root(tree))
+        @test map(label, tree["i_2"]) == all_labels(tree["i_2"])
+    end
+end
+
+
+@testset "Other" begin
+    nwk = "(((A1:1,A2:1,B:1,C:1)i_2:0.5,(D1:0,D2:0)i_3:1.5)i_1:1,(E:1.5,(F:1.0,(G:0.,H:0.)i_6:0.5)i_5:1)i_4:1)i_r;"
+    tree = parse_newick_string(nwk)
+    node_list = sort(["A1", "A2", "B", "C", "i_2", "D1", "D2", "i_3", "i_1", "E", "F", "G", "H", "i_6", "i_5", "i_4", "i_r"])
+    leaves_list = sort(["A1", "A2", "B", "C", "D1", "D2", "E", "F", "G", "H"])
+    internals_list = sort(setdiff(node_list, leaves_list))
+    internals_noroot_list = sort(filter(!=("i_r"), internals_list))
+
+    @testset "in" begin
+        for n in nodes(tree)
+            @test in(n, tree)
+            @test in(n.label, tree)
+            if !n.isleaf
+                @test !in(n, tree; exclude_internals=true)
+            end
+        end
+    end
+
+    @testset "indexing in tree" begin
+        for n in nodes(tree)
+            @test tree[n.label] == tree.lnodes[n.label]
+        end
+        @test_throws KeyError tree["some_random_string"]
+    end
 end

--- a/test/iterators/test.jl
+++ b/test/iterators/test.jl
@@ -3,7 +3,7 @@ using TreeTools
 
 # println("##### iterators #####")
 
-@testset "POT traversal" begin
+@testset "postorder traversal" begin
 	nwk = "(((A1:1,A2:1,B:1,C:1)i_2:0.5,(D1:0,D2:0)i_3:1.5)i_1:1,(E:1.5,(F:1.0,(G:0.,H:0.)i_6:0.5)i_5:1)i_4:1)i_r;"
 	tree = parse_newick_string(nwk);
 	node_list = sort(["A1", "A2", "B", "C", "i_2", "D1", "D2", "i_3", "i_1", "E", "F", "G", "H", "i_6", "i_5", "i_4", "i_r"])
@@ -11,11 +11,11 @@ using TreeTools
     internals_list = sort(setdiff(node_list, leaves_list))
     internals_noroot_list = sort(filter(!=("i_r"), internals_list))
 
-	@testset "Core function _POT" begin
+	@testset "Core function _postorder" begin
         R = root(tree)
-		@test sort([x.label for x in TreeTools._POT(R)]) == node_list
-		@test sort([x.label for x in TreeTools._POT(isleaf, R)]) == leaves_list
-        @test sort([x.label for x in TreeTools._POT(isinternal, R)]) == internals_list
+		@test sort([x.label for x in TreeTools._postorder(R)]) == node_list
+		@test sort([x.label for x in TreeTools._postorder(isleaf, R)]) == leaves_list
+        @test sort([x.label for x in TreeTools._postorder(isinternal, R)]) == internals_list
 	end
 
     @testset "postorder_traversal: basics" begin
@@ -33,26 +33,48 @@ using TreeTools
         @test X == Y
     end
 
-    @testset "postorder_traversal: node order" begin
-        function all_labels(node, holder = [])
-            for c in children(node)
-                all_labels(c, holder)
-            end
-            push!(holder, label(node))
+   function postorder_labels(node, holder = [])
+        for c in children(node)
+            postorder_labels(c, holder)
         end
-        @test [x.label for x in postorder_traversal(tree)] == all_labels(root(tree))
-        @test map(label, postorder_traversal(tree["i_2"])) == all_labels(tree["i_2"])
+        push!(holder, label(node))
+    end
+    @testset "postorder_traversal: node order" begin
+        @test [x.label for x in postorder_traversal(tree)] == postorder_labels(root(tree))
+        @test map(label, postorder_traversal(tree["i_2"])) == postorder_labels(tree["i_2"])
     end
 
     @testset "map - based on postorder" begin
-        function all_labels(node, holder = [])
-            for c in children(node)
-                all_labels(c, holder)
-            end
-            push!(holder, label(node))
+        @test map(label, tree) == postorder_labels(root(tree))
+        @test map(label, tree["i_2"]) == postorder_labels(tree["i_2"])
+    end
+end
+
+@testset "preorder traversal" begin
+    function preorder_labels(node::TreeNode, holder = []; func = x -> true)
+        func(node) && push!(holder, label(node))
+        for c in children(node)
+            preorder_labels(c, holder; func)
         end
-        @test map(label, tree) == all_labels(root(tree))
-        @test map(label, tree["i_2"]) == all_labels(tree["i_2"])
+        return holder
+    end
+    preorder_labels(tree::Tree; kwargs...) = preorder_labels(root(tree); kwargs...)
+
+    @testset "Normal tree" begin
+        newick_str = "((A,B)C,(D,E)F)G;"
+        tree = parse_newick_string(newick_str)
+        @test map(label, traversal(tree, :preorder)) == preorder_labels(tree)
+        @test map(label, traversal(tree["F"], :preorder)) == preorder_labels(tree["F"])
+        func(x) = label(x) != "F"
+        @test map(label, traversal(func, tree, :preorder)) == preorder_labels(tree; func)
+    end
+    @testset "Singleton tree" begin
+        newick_str = "(((A)B)C)R;"
+        tree = parse_newick_string(newick_str; strict_check=false)
+        @test map(label, traversal(tree, :preorder)) == preorder_labels(tree)
+        @test map(label, traversal(tree["C"], :preorder)) == preorder_labels(tree["C"])
+        func(x) = label(x) != "C"
+        @test map(label, traversal(func, tree, :preorder)) == preorder_labels(tree; func)
     end
 end
 

--- a/test/methods/test.jl
+++ b/test/methods/test.jl
@@ -52,8 +52,8 @@ end
 	t4 = copy(t1, label="tree_4")
 	@test typeof(t1) == typeof(t2)
 	prunesubtree!(t2, ["A"])
-	@test haskey(t1.lnodes, "A")
-	@test !haskey(t2.lnodes, "A")
+	@test "A" in t1
+	@test !in("A", t2)
 	@test t1.label == t2.label
 	@test t1.label != t3.label
 	@test t1.label != t4.label
@@ -191,7 +191,7 @@ end
     @test tree["B"] |> ancestor |> isroot
     @test pw_distances == [distance(tree, x, y) for x in leaf_labels for y in leaf_labels]
 
-    @test_throws ErrorException redirect_stderr(
+    @test_throws ArgumentError redirect_stderr(
         () -> TreeTools.root!(tree, "B"; time = 5), devnull
     )
 end

--- a/test/objects/test.jl
+++ b/test/objects/test.jl
@@ -5,18 +5,18 @@ using Test
 
 @testset "Node relabel" begin
 	nwk = "(A,(B,C));"
-	t = parse_newick_string(nwk)
-	label!(t, t["A"], "D")
-	@test check_tree(t)
-	@test !in("A", t)
-	@test in("D", t)
-	@test length(nodes(t)) == 5
-	labels = map(label, POT(t))
+	tree = parse_newick_string(nwk)
+	label!(tree, tree["A"], "D")
+	@test check_tree(tree)
+	@test !in("A", tree)
+	@test in("D", tree)
+	@test length(nodes(tree)) == 5
+	labels = map(label, postorder_traversal(tree))
 	@test !in("A", labels)
 	@test in("D", labels)
-	@test sort(labels) == sort(collect(keys(t.lnodes)))
+	@test sort(labels) == sort(map(label, tree))
 
-	@test_throws AssertionError label!(t, t["D"], "B")
-	@test_throws AssertionError label!(t, "D", "B")
+	@test_throws AssertionError label!(tree, tree["D"], "B")
+	@test_throws AssertionError label!(tree, "D", "B")
 end
 

--- a/test/prunegraft/test.jl
+++ b/test/prunegraft/test.jl
@@ -38,46 +38,50 @@ end
 	nwk = "((A:1,B:1)AB:2,(C:1,D:1)CD:2)R;"
 	t = parse_newick_string(nwk; node_data_type = TreeTools.EmptyData)
 
-	# 1
-	E = TreeNode(label = "E", tau = 4.)
-	tc = copy(t)
-	graft!(tc, E, "AB")
-	@test sort(map(label, children(tc["AB"]))) == ["A","B","E"]
-	@test ancestor(E) == tc["AB"]
-	@test in(E, tc)
-	@test in(E, children(tc["AB"]))
-	@test branch_length(E) == 4
-	@test_throws ErrorException graft!(tc, E, "CD") # E is not a root anymore
+	@testset "1" begin
+	    E = TreeNode(label = "E", tau = 4.)
+	    tc = copy(t)
+	    graft!(tc, E, "AB")
+	    @test sort(map(label, children(tc["AB"]))) == ["A","B","E"]
+	    @test ancestor(E) == tc["AB"]
+	    @test in(E, tc)
+	    @test in(E, children(tc["AB"]))
+	    @test branch_length(E) == 4
+	    @test_throws ArgumentError graft!(tc, E, "CD") # E is not a root anymore
+    end
 
-	# 2
-	E = TreeNode(label = "E", tau = 5.)
-	tc = copy(t)
-	@test_throws ErrorException graft!(tc, E, tc["A"])
-	graft!(tc, E, tc["A"], graft_on_leaf=true, time = 1.)
-	@test !isleaf(tc["A"])
-	@test ancestor(E) == tc["A"]
-	@test in(E, tc)
-	@test in(E, children(tc["A"]))
-	@test branch_length(E) == 1
+	@testset "2" begin
+	    E = TreeNode(label = "E", tau = 5.)
+	    tc = copy(t)
+	    @test_throws ArgumentError graft!(tc, E, tc["A"])
+	    graft!(tc, E, tc["A"], graft_on_leaf=true, time = 1.)
+	    @test !isleaf(tc["A"])
+	    @test ancestor(E) == tc["A"]
+	    @test in(E, tc)
+    	@test in(E, children(tc["A"]))
+    	@test branch_length(E) == 1
+    end
 
-	# 3
-	E = node2tree(TreeNode(label = "E", tau = 5.))
-	tc = copy(t)
-	graft!(tc, E, "A", graft_on_leaf=true) # will copy E
-	@test sort(map(label, children(tc["A"]))) == ["E"]
-	@test isroot(E.root)
-	@test check_tree(E)
-	@test in("E", tc)
-	@test_throws ErrorException graft!(tc, E, "CD")
+	@testset "3" begin
+	    E = node2tree(TreeNode(label = "E", tau = 5.))
+	    tc = copy(t)
+	    graft!(tc, E, "A", graft_on_leaf=true) # will copy E
+	    @test sort(map(label, children(tc["A"]))) == ["E"]
+	    @test isroot(E.root)
+	    @test check_tree(E)
+	    @test in("E", tc)
+	    @test_throws ArgumentError graft!(tc, E, "CD")
+    end
 
-	# 4
-	E = TreeNode(label = "E", tau = 4., data = MiscData())
-	tc = copy(t)
-	@test_throws ErrorException graft!(tc, E, "AB")
+	@testset "4" begin
+	    E = TreeNode(label = "E", tau = 4., data = MiscData())
+	    tc = copy(t)
+	    @test_throws ArgumentError graft!(tc, E, "AB")
 
-	tc = convert(Tree{MiscData}, t)
-	E = TreeNode(label = "E", tau = 4.)
-	@test_throws ErrorException graft!(tc, E, "AB")
+	    tc = convert(Tree{MiscData}, t)
+	    E = TreeNode(label = "E", tau = 4.)
+	    @test_throws ArgumentError graft!(tc, E, "AB")
+    end
 end
 
 @testset "Pruning" begin
@@ -98,9 +102,9 @@ end
 
 	# 2
 	tc = copy(t)
-	@test_throws ErrorException prunesubtree!(tc, "R")
+	@test_throws ArgumentError prunesubtree!(tc, "R")
 	@test_throws KeyError prunesubtree!(tc, "X")
-	@test_throws ErrorException prune!(tc, ["A", "C"])
+	@test_throws ArgumentError prune!(tc, ["A", "C"])
 	prunesubtree!(tc, ["A", "B"])
 	@test_throws KeyError prunesubtree!(tc, "A")
 
@@ -128,10 +132,10 @@ end
 
 	# 1
 	tc = copy(t)
-	@test_throws ErrorException insert!(tc, "A"; time = 2.)
-	@test_throws ErrorException insert!(tc, "A"; time = missing)
-	@test_throws ErrorException insert!(tc, "A"; name = "B")
-	@test_throws ErrorException insert!(tc, "R"; time = 1.)
+	@test_throws ArgumentError insert!(tc, "A"; time = 2.)
+	@test_throws ArgumentError insert!(tc, "A"; time = missing)
+	@test_throws ArgumentError insert!(tc, "A"; name = "B")
+	@test_throws ArgumentError insert!(tc, "R"; time = 1.)
 
 	# 2
 	tc = convert(Tree{MiscData}, t)
@@ -163,7 +167,7 @@ end
 
 	# 1
 	tc = copy(t)
-	@test_throws ErrorException delete!(tc, "R")
+	@test_throws ArgumentError delete!(tc, "R")
 	delete!(tc, "AB")
 	@test sort(map(label, children(tc["R"]))) == ["A", "B", "CD"]
 	@test branch_length(tc["A"]) == 3


### PR DESCRIPTION
- Remove old traversal function `POT` and `POTleaves`. The bindings still exist but redirect to the new traversal function. 
- Add new functions `traversal(tree, style)`, in turn calling `postorder_traversal` or `preorder_traversal`. The implementation is based on the ResumableFunctions package. It's not very fast for small trees (w.r. to a recursive solution), but decent. 